### PR TITLE
feat: introduce core type system scaffolding

### DIFF
--- a/crates/specado-core/src/auth.rs
+++ b/crates/specado-core/src/auth.rs
@@ -1,0 +1,8 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum AuthScheme {
+    Bearer { token_env: String },
+    ApiKey { header: String, key_env: String },
+}

--- a/crates/specado-core/src/lib.rs
+++ b/crates/specado-core/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+pub mod auth;
 pub mod types;
 
 /// Placeholder module for the Specado core engine.

--- a/crates/specado-core/src/lib.rs
+++ b/crates/specado-core/src/lib.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code)]
 
+pub mod types;
+
 /// Placeholder module for the Specado core engine.
 pub mod placeholder {
     /// Temporary no-op to keep the crate building during scaffolding.

--- a/crates/specado-core/src/types/lossiness.rs
+++ b/crates/specado-core/src/types/lossiness.rs
@@ -1,0 +1,93 @@
+use super::prompt::StrictMode;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LossinessReport {
+    pub is_lossy: bool,
+    pub strict_mode: StrictMode,
+    pub entries: Vec<LossinessEntry>,
+    pub omissions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LossinessEntry {
+    pub code: LossinessCode,
+    pub level: LossinessLevel,
+    pub path: String,
+    pub reason: String,
+    pub suggested_fix: Option<String>,
+    pub details: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "PascalCase")]
+pub enum LossinessCode {
+    Clamp,
+    Drop,
+    Emulate,
+    Conflict,
+    Relocate,
+    Unsupported,
+    MapFallback,
+    PerformanceImpact,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum LossinessLevel {
+    Info,
+    Warn,
+    Error,
+}
+
+impl LossinessReport {
+    pub fn new(strict_mode: StrictMode) -> Self {
+        Self {
+            is_lossy: false,
+            strict_mode,
+            entries: Vec::new(),
+            omissions: Vec::new(),
+        }
+    }
+
+    pub fn add_entry(&mut self, entry: LossinessEntry) {
+        self.is_lossy = true;
+        self.entries.push(entry);
+    }
+
+    pub fn add_omission(&mut self, path: impl Into<String>) {
+        self.omissions.push(path.into());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn add_entry_marks_report_lossy() {
+        let mut report = LossinessReport::new(StrictMode::Warn);
+        report.add_entry(LossinessEntry {
+            code: LossinessCode::Clamp,
+            level: LossinessLevel::Warn,
+            path: "body.temperature".into(),
+            reason: "Value out of bounds".into(),
+            suggested_fix: Some("Clamp to provider range".into()),
+            details: Some(json!({"min": 0.0, "max": 1.0})),
+        });
+
+        assert!(report.is_lossy);
+        assert_eq!(report.entries.len(), 1);
+    }
+
+    #[test]
+    fn add_omission_tracks_paths() {
+        let mut report = LossinessReport::new(StrictMode::Strict);
+        report.add_omission("response.annotations");
+        report.add_omission("response.metadata");
+
+        assert_eq!(report.omissions.len(), 2);
+        assert_eq!(report.omissions[0], "response.annotations");
+    }
+}

--- a/crates/specado-core/src/types/mod.rs
+++ b/crates/specado-core/src/types/mod.rs
@@ -1,0 +1,1 @@
+pub mod prompt;

--- a/crates/specado-core/src/types/mod.rs
+++ b/crates/specado-core/src/types/mod.rs
@@ -2,3 +2,14 @@ pub mod lossiness;
 pub mod prompt;
 pub mod provider;
 pub mod response;
+
+pub use lossiness::{LossinessCode, LossinessEntry, LossinessLevel, LossinessReport};
+pub use prompt::{
+    JsonSchema, Message, MessageRole, PromptSpec, ResponseConfig, ResponseFormat, SamplingConfig,
+    StrictMode, Tool, ToolChoice, ToolChoiceString,
+};
+pub use provider::{
+    Constraints, EndpointConfig, Endpoints, HttpMethod, Mappings, ModelConfig, ProviderSpec,
+    RequestMapping, ResponseMapping, SupportFlags,
+};
+pub use response::{Extensions, FinishReason, UniformResponse, Usage};

--- a/crates/specado-core/src/types/mod.rs
+++ b/crates/specado-core/src/types/mod.rs
@@ -1,1 +1,2 @@
 pub mod prompt;
+pub mod provider;

--- a/crates/specado-core/src/types/mod.rs
+++ b/crates/specado-core/src/types/mod.rs
@@ -1,2 +1,3 @@
+pub mod lossiness;
 pub mod prompt;
 pub mod provider;

--- a/crates/specado-core/src/types/mod.rs
+++ b/crates/specado-core/src/types/mod.rs
@@ -1,3 +1,4 @@
 pub mod lossiness;
 pub mod prompt;
 pub mod provider;
+pub mod response;

--- a/crates/specado-core/src/types/prompt.rs
+++ b/crates/specado-core/src/types/prompt.rs
@@ -1,0 +1,189 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PromptSpec {
+    pub version: String,
+    pub messages: Vec<Message>,
+    #[serde(default)]
+    pub sampling: SamplingConfig,
+    #[serde(default)]
+    pub response: ResponseConfig,
+    #[serde(default)]
+    pub tools: Vec<Tool>,
+    #[serde(default)]
+    pub tool_choice: Option<ToolChoice>,
+    #[serde(default)]
+    pub strict_mode: StrictMode,
+    #[serde(default)]
+    pub metadata: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Message {
+    pub role: MessageRole,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum MessageRole {
+    System,
+    User,
+    Assistant,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct SamplingConfig {
+    pub temperature: Option<f64>,
+    pub top_p: Option<f64>,
+    pub top_k: Option<u32>,
+    pub frequency_penalty: Option<f64>,
+    pub presence_penalty: Option<f64>,
+    pub seed: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ResponseConfig {
+    #[serde(default = "default_format")]
+    pub format: ResponseFormat,
+    pub json_schema: Option<JsonSchema>,
+}
+
+fn default_format() -> ResponseFormat {
+    ResponseFormat::Text
+}
+
+impl Default for ResponseConfig {
+    fn default() -> Self {
+        Self {
+            format: ResponseFormat::Text,
+            json_schema: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ResponseFormat {
+    Text,
+    Json,
+    JsonSchema,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct JsonSchema {
+    pub name: String,
+    pub description: Option<String>,
+    pub schema: serde_json::Value,
+    #[serde(default)]
+    pub strict: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Tool {
+    pub name: String,
+    pub description: Option<String>,
+    pub json_schema: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum ToolChoice {
+    String(ToolChoiceString),
+    Object { name: String },
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ToolChoiceString {
+    Auto,
+    Required,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "PascalCase")]
+pub enum StrictMode {
+    Strict,
+    Warn,
+    Coerce,
+}
+
+impl Default for StrictMode {
+    fn default() -> Self {
+        StrictMode::Warn
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn response_config_defaults_to_text() {
+        let config = ResponseConfig::default();
+        assert_eq!(config.format, ResponseFormat::Text);
+        assert!(config.json_schema.is_none());
+    }
+
+    #[test]
+    fn strict_mode_default_is_warn() {
+        let prompt: PromptSpec = serde_json::from_value(json!({
+            "version": "1",
+            "messages": [
+                {"role": "user", "content": "Hello"}
+            ]
+        }))
+        .expect("prompt should deserialize");
+
+        assert_eq!(prompt.strict_mode, StrictMode::Warn);
+    }
+
+    #[test]
+    fn round_trip_prompt_spec() {
+        let prompt = PromptSpec {
+            version: "1".to_string(),
+            messages: vec![Message {
+                role: MessageRole::System,
+                content: "You are helpful.".into(),
+            }],
+            sampling: SamplingConfig {
+                temperature: Some(0.7),
+                top_p: Some(0.9),
+                top_k: Some(20),
+                frequency_penalty: None,
+                presence_penalty: None,
+                seed: Some(42),
+            },
+            response: ResponseConfig {
+                format: ResponseFormat::JsonSchema,
+                json_schema: Some(JsonSchema {
+                    name: "summary".into(),
+                    description: Some("Short summary".into()),
+                    schema: json!({"type": "object"}),
+                    strict: true,
+                }),
+            },
+            tools: vec![Tool {
+                name: "search".into(),
+                description: Some("Lookup".into()),
+                json_schema: json!({"type": "object"}),
+            }],
+            tool_choice: Some(ToolChoice::String(ToolChoiceString::Auto)),
+            strict_mode: StrictMode::Strict,
+            metadata: HashMap::from([(String::from("source"), json!("test"))]),
+        };
+
+        let serialized = serde_json::to_string_pretty(&prompt).expect("serialize");
+        let deserialized: PromptSpec = serde_json::from_str(&serialized).expect("deserialize");
+        assert_eq!(deserialized.version, prompt.version);
+        assert_eq!(deserialized.messages, prompt.messages);
+        assert_eq!(deserialized.response.format, ResponseFormat::JsonSchema);
+        assert_eq!(deserialized.tools.len(), 1);
+        assert!(matches!(
+            deserialized.tool_choice,
+            Some(ToolChoice::String(ToolChoiceString::Auto))
+        ));
+    }
+}

--- a/crates/specado-core/src/types/provider.rs
+++ b/crates/specado-core/src/types/provider.rs
@@ -1,0 +1,146 @@
+use crate::auth::AuthScheme;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ProviderSpec {
+    pub provider: String,
+    pub models: Vec<ModelConfig>,
+    pub endpoints: Endpoints,
+    pub mappings: Mappings,
+    pub constraints: Constraints,
+    pub auth: AuthScheme,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ModelConfig {
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Endpoints {
+    pub chat: EndpointConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct EndpointConfig {
+    pub method: HttpMethod,
+    pub url: String,
+    #[serde(default)]
+    pub headers: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum HttpMethod {
+    Post,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Mappings {
+    pub request: Vec<RequestMapping>,
+    pub response: Vec<ResponseMapping>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RequestMapping {
+    pub from: String,
+    pub to: String,
+    #[serde(default)]
+    pub code: Option<String>,
+    #[serde(default)]
+    pub clamp: Option<[f64; 2]>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ResponseMapping {
+    pub from: String,
+    pub to: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Constraints {
+    pub supports: SupportFlags,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SupportFlags {
+    pub json_mode: bool,
+    pub tools: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_yaml;
+
+    #[test]
+    fn deserialize_bearer_provider() {
+        let yaml = r#"
+provider: openai
+models:
+  - id: gpt-4o
+endpoints:
+  chat:
+    method: POST
+    url: https://api.openai.com/v1/chat/completions
+    headers:
+      content-type: application/json
+mappings:
+  request:
+    - from: prompt.messages
+      to: body.messages
+  response:
+    - from: body.choices[0].message
+      to: prompt.response
+constraints:
+  supports:
+    json_mode: true
+    tools: true
+auth:
+  type: bearer
+  token_env: OPENAI_API_KEY
+"#;
+
+        let spec: ProviderSpec = serde_yaml::from_str(yaml).expect("valid provider spec");
+
+        assert_eq!(spec.provider, "openai");
+        assert_eq!(spec.models.len(), 1);
+        assert!(matches!(spec.auth, AuthScheme::Bearer { .. }));
+    }
+
+    #[test]
+    fn deserialize_apikey_provider() {
+        let yaml = r#"
+provider: custom
+models:
+  - id: custom-model
+endpoints:
+  chat:
+    method: POST
+    url: https://example.com/chat
+    headers: {}
+mappings:
+  request: []
+  response: []
+constraints:
+  supports:
+    json_mode: false
+    tools: false
+auth:
+  type: apikey
+  header: X-API-Key
+  key_env: CUSTOM_KEY
+"#;
+
+        let spec: ProviderSpec = serde_yaml::from_str(yaml).expect("valid provider spec");
+
+        match spec.auth {
+            AuthScheme::ApiKey { header, key_env } => {
+                assert_eq!(header, "X-API-Key");
+                assert_eq!(key_env, "CUSTOM_KEY");
+            }
+            _ => panic!("expected apikey variant"),
+        }
+    }
+}

--- a/crates/specado-core/src/types/response.rs
+++ b/crates/specado-core/src/types/response.rs
@@ -1,0 +1,100 @@
+use super::lossiness::LossinessReport;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct UniformResponse {
+    pub content: String,
+    #[serde(default)]
+    pub tool_calls: Vec<serde_json::Value>,
+    pub finish_reason: FinishReason,
+    pub model: String,
+    pub provider_used: String,
+    #[serde(default)]
+    pub usage: Option<Usage>,
+    pub extensions: Extensions,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum FinishReason {
+    Stop,
+    Length,
+    ToolCall,
+    ContentFilter,
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Usage {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Extensions {
+    pub lossiness: LossinessReport,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::lossiness::{LossinessEntry, LossinessLevel};
+    use crate::types::prompt::StrictMode;
+    use serde_json::json;
+
+    #[test]
+    fn round_trip_uniform_response() {
+        let mut report = LossinessReport::new(StrictMode::Warn);
+        report.add_entry(LossinessEntry {
+            code: crate::types::lossiness::LossinessCode::Drop,
+            level: LossinessLevel::Info,
+            path: "response.metadata".into(),
+            reason: "Metadata omitted".into(),
+            suggested_fix: None,
+            details: None,
+        });
+
+        let response = UniformResponse {
+            content: "Hello".into(),
+            tool_calls: vec![json!({"id": "call-1"})],
+            finish_reason: FinishReason::Stop,
+            model: "gpt-4o".into(),
+            provider_used: "openai".into(),
+            usage: Some(Usage {
+                prompt_tokens: 12,
+                completion_tokens: 34,
+            }),
+            extensions: Extensions { lossiness: report },
+        };
+
+        let serialized = serde_json::to_string(&response).expect("serialize");
+        let decoded: UniformResponse = serde_json::from_str(&serialized).expect("deserialize");
+
+        assert_eq!(decoded.finish_reason, FinishReason::Stop);
+        assert_eq!(decoded.tool_calls.len(), 1);
+        assert!(decoded.extensions.lossiness.is_lossy);
+    }
+
+    #[test]
+    fn default_fields_populate() {
+        let payload = json!({
+            "content": "Hi",
+            "finish_reason": "error",
+            "model": "mistral",
+            "provider_used": "anthropic",
+            "extensions": {
+                "lossiness": {
+                    "is_lossy": false,
+                    "strict_mode": "Warn",
+                    "entries": [],
+                    "omissions": []
+                }
+            }
+        });
+
+        let decoded: UniformResponse = serde_json::from_value(payload).expect("decode");
+        assert!(decoded.tool_calls.is_empty());
+        assert!(decoded.usage.is_none());
+        assert!(!decoded.extensions.lossiness.is_lossy);
+    }
+}


### PR DESCRIPTION
## Summary
- add prompt spec types with defaults and serde coverage (#26)
- define provider spec + auth scheme structures matching the schema (#27)
- introduce lossiness report and uniform response models with tests (#28, #29)
- expose a types barrel so downstream modules import from a single surface (#25)

## Testing
- cargo test -p specado-core
