### PR TITLE
feat: add core error and auth handling

### DIFF
--- a/crates/specado-core/src/auth.rs
+++ b/crates/specado-core/src/auth.rs
@@ -1,19 +1,163 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use thiserror::Error;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum AuthScheme {
-    Bearer { token_env: String },
-    ApiKey { header: String, key_env: String },
+    Bearer {
+        token_env: String,
+    },
+    #[serde(rename = "apikey")]
+    ApiKey {
+        header: String,
+        key_env: String,
+    },
+    Custom {
+        headers: HashMap<String, String>,
+    },
 }
 
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum AuthError {
-    #[error("Missing required environment variable: {0}")]
+    #[error("Missing environment variable: {0}")]
     MissingEnvVar(String),
-    #[error("Unsupported auth scheme: {0}")]
-    UnsupportedScheme(String),
-    #[error("Failed to inject authentication headers: {0}")]
-    HeaderInjection(String),
+    #[error("Invalid auth configuration: {0}")]
+    InvalidConfig(String),
+}
+
+pub struct AuthHandler {
+    scheme: AuthScheme,
+}
+
+impl AuthHandler {
+    pub fn new(scheme: AuthScheme) -> Self {
+        Self { scheme }
+    }
+
+    pub fn scheme(&self) -> &AuthScheme {
+        &self.scheme
+    }
+
+    pub fn validate(&self) -> Result<(), AuthError> {
+        match &self.scheme {
+            AuthScheme::Bearer { token_env } => {
+                Self::require_env(token_env)?;
+            }
+            AuthScheme::ApiKey { key_env, .. } => {
+                Self::require_env(key_env)?;
+            }
+            AuthScheme::Custom { headers } => {
+                for value in headers.values() {
+                    Self::expand_env_var(value)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn inject_headers(&self, headers: &mut HashMap<String, String>) -> Result<(), AuthError> {
+        match &self.scheme {
+            AuthScheme::Bearer { token_env } => {
+                let token = Self::require_env(token_env)?;
+                headers.insert("Authorization".to_string(), format!("Bearer {}", token));
+            }
+            AuthScheme::ApiKey { header, key_env } => {
+                let key = Self::require_env(key_env)?;
+                headers.insert(header.clone(), key);
+            }
+            AuthScheme::Custom { headers: custom } => {
+                for (key, value_template) in custom {
+                    let value = Self::expand_env_var(value_template)?;
+                    headers.insert(key.clone(), value);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn require_env(var: &str) -> Result<String, AuthError> {
+        std::env::var(var).map_err(|_| AuthError::MissingEnvVar(var.to_string()))
+    }
+
+    fn expand_env_var(template: &str) -> Result<String, AuthError> {
+        if let Some(stripped) = template
+            .strip_prefix("${ENV:")
+            .and_then(|s| s.strip_suffix('}'))
+        {
+            Self::require_env(stripped)
+        } else if template.contains("${ENV:") {
+            Err(AuthError::InvalidConfig(template.to_string()))
+        } else {
+            Ok(template.to_string())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unset(name: &str) {
+        std::env::remove_var(name);
+    }
+
+    #[test]
+    fn bearer_missing_env_returns_error() {
+        let var = "SPECADO_TEST_TOKEN";
+        unset(var);
+        let handler = AuthHandler::new(AuthScheme::Bearer {
+            token_env: var.to_string(),
+        });
+        let mut headers = HashMap::new();
+        let err = handler.inject_headers(&mut headers).unwrap_err();
+        assert!(matches!(err, AuthError::MissingEnvVar(m) if m == var));
+    }
+
+    #[test]
+    fn injects_bearer_header() {
+        let var = "SPECADO_TEST_TOKEN_OK";
+        std::env::set_var(var, "token-value");
+        let handler = AuthHandler::new(AuthScheme::Bearer {
+            token_env: var.to_string(),
+        });
+        let mut headers = HashMap::new();
+        handler.inject_headers(&mut headers).unwrap();
+        assert_eq!(headers.get("Authorization").unwrap(), "Bearer token-value");
+        unset(var);
+    }
+
+    #[test]
+    fn custom_env_expansion() {
+        let key = "SPECADO_CUSTOM_KEY";
+        std::env::set_var(key, "123");
+        let handler = AuthHandler::new(AuthScheme::Custom {
+            headers: HashMap::from([(
+                "X-Api-Key".to_string(),
+                "${ENV:SPECADO_CUSTOM_KEY}".to_string(),
+            )]),
+        });
+        let mut headers = HashMap::new();
+        handler.inject_headers(&mut headers).unwrap();
+        assert_eq!(headers["X-Api-Key"], "123");
+        unset(key);
+    }
+
+    #[test]
+    fn validate_checks_custom_placeholders() {
+        let handler = AuthHandler::new(AuthScheme::Custom {
+            headers: HashMap::from([("X-Thing".to_string(), "${ENV:SPECADO_MISSING}".to_string())]),
+        });
+        let err = handler.validate().unwrap_err();
+        assert!(matches!(err, AuthError::MissingEnvVar(var) if var == "SPECADO_MISSING"));
+    }
+
+    #[test]
+    fn invalid_placeholder_returns_invalid_config() {
+        let handler = AuthHandler::new(AuthScheme::Custom {
+            headers: HashMap::from([("X-Thing".to_string(), "${ENV:UNTERMINATED".to_string())]),
+        });
+        let err = handler.validate().unwrap_err();
+        assert!(matches!(err, AuthError::InvalidConfig(_)));
+    }
 }

--- a/crates/specado-core/src/auth.rs
+++ b/crates/specado-core/src/auth.rs
@@ -1,8 +1,19 @@
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum AuthScheme {
     Bearer { token_env: String },
     ApiKey { header: String, key_env: String },
+}
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum AuthError {
+    #[error("Missing required environment variable: {0}")]
+    MissingEnvVar(String),
+    #[error("Unsupported auth scheme: {0}")]
+    UnsupportedScheme(String),
+    #[error("Failed to inject authentication headers: {0}")]
+    HeaderInjection(String),
 }

--- a/crates/specado-core/src/error.rs
+++ b/crates/specado-core/src/error.rs
@@ -1,0 +1,88 @@
+use crate::auth::AuthError;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Configuration error: {0}")]
+    Config(String),
+
+    #[error("Schema validation failed: {0}")]
+    SchemaValidation(String),
+
+    #[error("Provider error ({provider}): {kind:?}")]
+    Provider {
+        provider: String,
+        kind: ProviderErrorKind,
+    },
+
+    #[error("Transform error: {0}")]
+    Transform(String),
+
+    #[error("Strict mode violation")]
+    StrictModeViolation,
+
+    #[error("Circuit breaker is open")]
+    CircuitBreakerOpen,
+
+    #[error("Circuit breaker is half-open, rejecting request")]
+    CircuitBreakerHalfOpen,
+
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Authentication error: {0}")]
+    Auth(#[from] AuthError),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProviderErrorKind {
+    RateLimit,
+    Timeout,
+    InvalidRequest,
+    AuthenticationFailed,
+    ServerError,
+    Unknown,
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::AuthError;
+
+    #[test]
+    fn wraps_io_error() {
+        let err = std::io::Error::new(std::io::ErrorKind::Other, "disk failed");
+        let wrapped = Error::from(err);
+        matches!(wrapped, Error::Io(_))
+            .then_some(())
+            .expect("io errors map to Error::Io");
+    }
+
+    #[test]
+    fn wraps_json_error() {
+        let err = serde_json::from_str::<serde_json::Value>("not-json").unwrap_err();
+        let wrapped = Error::from(err);
+        assert!(matches!(wrapped, Error::Json(_)));
+    }
+
+    #[test]
+    fn auth_error_converts() {
+        let auth_err = AuthError::MissingEnvVar("OPENAI_API_KEY".into());
+        let wrapped = Error::from(auth_err);
+        assert!(matches!(wrapped, Error::Auth(_)));
+    }
+
+    #[test]
+    fn provider_error_kind_debug() {
+        let kind = ProviderErrorKind::RateLimit;
+        assert_eq!(format!("{:?}", kind), "RateLimit");
+    }
+}

--- a/crates/specado-core/src/lib.rs
+++ b/crates/specado-core/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 pub mod auth;
+pub mod error;
 pub mod types;
 
 /// Placeholder module for the Specado core engine.


### PR DESCRIPTION
## Summary
- define cohesive `Error` enum with provider, transform, and external error variants (#23)
- expose `AuthHandler` supporting bearer/apikey/custom header schemes with env validation (#24)
- add targeted unit tests for error conversions and header injection flows

## Testing
- cargo test -p specado-core

Closes #23
Closes #24