### PR TITLE
feat: add transformer detect utilities

### DIFF
--- a/crates/specado-core/src/lib.rs
+++ b/crates/specado-core/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod auth;
 pub mod error;
+pub mod transformer;
 pub mod types;
 
 /// Placeholder module for the Specado core engine.

--- a/crates/specado-core/src/transformer/detect/clamp.rs
+++ b/crates/specado-core/src/transformer/detect/clamp.rs
@@ -1,0 +1,83 @@
+use crate::types::{LossinessCode, LossinessEntry, LossinessLevel, LossinessReport};
+use serde_json::json;
+
+pub fn clamp_value(
+    value: f64,
+    range: [f64; 2],
+    path: impl Into<String>,
+    report: &mut LossinessReport,
+) -> f64 {
+    let [min, max] = range;
+    let path = path.into();
+
+    if value < min {
+        report.add_entry(LossinessEntry {
+            code: LossinessCode::Clamp,
+            level: LossinessLevel::Warn,
+            path: path.clone(),
+            reason: format!("Value {} below minimum {}", value, min),
+            suggested_fix: Some(format!("Use value >= {}", min)),
+            details: Some(json!({
+                "requested": value,
+                "clamped_to": min,
+            })),
+        });
+        min
+    } else if value > max {
+        report.add_entry(LossinessEntry {
+            code: LossinessCode::Clamp,
+            level: LossinessLevel::Warn,
+            path: path.clone(),
+            reason: format!("Value {} above maximum {}", value, max),
+            suggested_fix: Some(format!("Use value <= {}", max)),
+            details: Some(json!({
+                "requested": value,
+                "clamped_to": max,
+            })),
+        });
+        max
+    } else {
+        value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::StrictMode;
+
+    fn fresh_report() -> LossinessReport {
+        LossinessReport::new(StrictMode::Warn)
+    }
+
+    #[test]
+    fn clamps_value_below_min() {
+        let mut report = fresh_report();
+        let result = clamp_value(-1.0, [0.0, 2.0], "sampling.temperature", &mut report);
+        assert_eq!(result, 0.0);
+        assert!(report.is_lossy);
+        assert_eq!(report.entries.len(), 1);
+        assert_eq!(report.entries[0].path, "sampling.temperature");
+    }
+
+    #[test]
+    fn clamps_value_above_max() {
+        let mut report = fresh_report();
+        let result = clamp_value(3.5, [0.0, 2.0], "sampling.temperature", &mut report);
+        assert_eq!(result, 2.0);
+        assert!(report.is_lossy);
+        assert_eq!(
+            report.entries[0].details.as_ref().unwrap()["clamped_to"],
+            2.0
+        );
+    }
+
+    #[test]
+    fn leaves_value_in_range() {
+        let mut report = fresh_report();
+        let result = clamp_value(1.2, [0.0, 2.0], "sampling.temperature", &mut report);
+        assert_eq!(result, 1.2);
+        assert!(!report.is_lossy);
+        assert!(report.entries.is_empty());
+    }
+}

--- a/crates/specado-core/src/transformer/detect/drop.rs
+++ b/crates/specado-core/src/transformer/detect/drop.rs
@@ -1,0 +1,126 @@
+use crate::types::{
+    LossinessCode, LossinessEntry, LossinessLevel, LossinessReport, PromptSpec, ProviderSpec,
+};
+use serde_json::json;
+
+pub fn detect_drops(prompt: &PromptSpec, provider: &ProviderSpec, report: &mut LossinessReport) {
+    if let Some(top_k) = prompt.sampling.top_k {
+        let has_top_k_mapping = provider
+            .mappings
+            .request
+            .iter()
+            .any(|mapping| mapping.from.contains("top_k"));
+
+        if !has_top_k_mapping {
+            report.add_entry(LossinessEntry {
+                code: LossinessCode::Drop,
+                level: LossinessLevel::Warn,
+                path: "sampling.top_k".to_string(),
+                reason: "Parameter not supported by provider".to_string(),
+                suggested_fix: Some("Remove top_k or use a provider that supports it".to_string()),
+                details: Some(json!({ "requested": top_k })),
+            });
+            report.add_omission("$.sampling.top_k".to_string());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{
+        Constraints, EndpointConfig, Endpoints, HttpMethod, Mappings, ModelConfig, RequestMapping,
+        ResponseConfig, ResponseMapping, SamplingConfig, StrictMode, SupportFlags,
+    };
+
+    fn provider_with_top_k_mapping(has_mapping: bool) -> ProviderSpec {
+        let mut request = Vec::new();
+        if has_mapping {
+            request.push(RequestMapping {
+                from: "sampling.top_k".into(),
+                to: "body.top_k".into(),
+                code: None,
+                clamp: None,
+            });
+        }
+
+        ProviderSpec {
+            provider: "demo".into(),
+            models: vec![ModelConfig { id: "demo".into() }],
+            endpoints: Endpoints {
+                chat: EndpointConfig {
+                    method: HttpMethod::Post,
+                    url: "https://demo".into(),
+                    headers: Default::default(),
+                },
+            },
+            mappings: Mappings {
+                request,
+                response: vec![ResponseMapping {
+                    from: "body".into(),
+                    to: "response".into(),
+                }],
+            },
+            constraints: Constraints {
+                supports: SupportFlags {
+                    json_mode: true,
+                    tools: true,
+                },
+            },
+            auth: crate::auth::AuthScheme::Bearer {
+                token_env: "TOKEN".into(),
+            },
+        }
+    }
+
+    fn prompt_with_top_k(value: Option<u32>) -> PromptSpec {
+        PromptSpec {
+            version: "1".into(),
+            messages: vec![crate::types::Message {
+                role: crate::types::MessageRole::User,
+                content: "Hello".into(),
+            }],
+            sampling: SamplingConfig {
+                top_k: value,
+                ..Default::default()
+            },
+            response: ResponseConfig::default(),
+            tools: Vec::new(),
+            tool_choice: None,
+            strict_mode: StrictMode::Warn,
+            metadata: Default::default(),
+        }
+    }
+
+    #[test]
+    fn records_drop_when_mapping_missing() {
+        let prompt = prompt_with_top_k(Some(50));
+        let provider = provider_with_top_k_mapping(false);
+        let mut report = LossinessReport::new(StrictMode::Warn);
+
+        detect_drops(&prompt, &provider, &mut report);
+        assert!(report.is_lossy);
+        assert_eq!(report.entries[0].code, LossinessCode::Drop);
+        assert_eq!(report.omissions, vec!["$.sampling.top_k"]);
+    }
+
+    #[test]
+    fn no_drop_when_mapping_present() {
+        let prompt = prompt_with_top_k(Some(50));
+        let provider = provider_with_top_k_mapping(true);
+        let mut report = LossinessReport::new(StrictMode::Warn);
+
+        detect_drops(&prompt, &provider, &mut report);
+        assert!(!report.is_lossy);
+    }
+
+    #[test]
+    fn ignores_when_top_k_not_set() {
+        let prompt = prompt_with_top_k(None);
+        let provider = provider_with_top_k_mapping(false);
+        let mut report = LossinessReport::new(StrictMode::Warn);
+
+        detect_drops(&prompt, &provider, &mut report);
+        assert!(!report.is_lossy);
+    }
+}

--- a/crates/specado-core/src/transformer/detect/mod.rs
+++ b/crates/specado-core/src/transformer/detect/mod.rs
@@ -1,0 +1,1 @@
+pub mod clamp;

--- a/crates/specado-core/src/transformer/detect/mod.rs
+++ b/crates/specado-core/src/transformer/detect/mod.rs
@@ -1,2 +1,3 @@
 pub mod clamp;
 pub mod relocate;
+pub mod unsupported;

--- a/crates/specado-core/src/transformer/detect/mod.rs
+++ b/crates/specado-core/src/transformer/detect/mod.rs
@@ -2,3 +2,8 @@ pub mod clamp;
 pub mod drop;
 pub mod relocate;
 pub mod unsupported;
+
+pub use clamp::clamp_value;
+pub use drop::detect_drops;
+pub use relocate::detect_relocate;
+pub use unsupported::detect_unsupported;

--- a/crates/specado-core/src/transformer/detect/mod.rs
+++ b/crates/specado-core/src/transformer/detect/mod.rs
@@ -1,1 +1,2 @@
 pub mod clamp;
+pub mod relocate;

--- a/crates/specado-core/src/transformer/detect/mod.rs
+++ b/crates/specado-core/src/transformer/detect/mod.rs
@@ -1,3 +1,4 @@
 pub mod clamp;
+pub mod drop;
 pub mod relocate;
 pub mod unsupported;

--- a/crates/specado-core/src/transformer/detect/relocate.rs
+++ b/crates/specado-core/src/transformer/detect/relocate.rs
@@ -1,6 +1,6 @@
 use crate::types::{
-    LossinessCode, LossinessEntry, LossinessLevel, LossinessReport, Message, MessageRole,
-    PromptSpec, ProviderSpec,
+    LossinessCode, LossinessEntry, LossinessLevel, LossinessReport, MessageRole, PromptSpec,
+    ProviderSpec,
 };
 use serde_json::json;
 
@@ -38,8 +38,8 @@ pub fn detect_relocate(prompt: &PromptSpec, provider: &ProviderSpec, report: &mu
 mod tests {
     use super::*;
     use crate::types::{
-        Constraints, EndpointConfig, Endpoints, HttpMethod, Mappings, ModelConfig, RequestMapping,
-        ResponseMapping, StrictMode, SupportFlags,
+        Constraints, EndpointConfig, Endpoints, HttpMethod, Mappings, Message, ModelConfig,
+        RequestMapping, ResponseMapping, StrictMode, SupportFlags,
     };
 
     fn base_provider(code: Option<&str>) -> ProviderSpec {

--- a/crates/specado-core/src/transformer/detect/relocate.rs
+++ b/crates/specado-core/src/transformer/detect/relocate.rs
@@ -1,0 +1,140 @@
+use crate::types::{
+    LossinessCode, LossinessEntry, LossinessLevel, LossinessReport, Message, MessageRole,
+    PromptSpec, ProviderSpec,
+};
+use serde_json::json;
+
+pub fn detect_relocate(prompt: &PromptSpec, provider: &ProviderSpec, report: &mut LossinessReport) {
+    let has_system = prompt
+        .messages
+        .iter()
+        .any(|m| m.role == MessageRole::System);
+
+    if !has_system {
+        return;
+    }
+
+    if let Some(mapping) = provider
+        .mappings
+        .request
+        .iter()
+        .find(|m| m.code.as_deref() == Some("Relocate"))
+    {
+        report.add_entry(LossinessEntry {
+            code: LossinessCode::Relocate,
+            level: LossinessLevel::Info,
+            path: "messages[0]".to_string(),
+            reason: "System message relocated to provider-specific location".to_string(),
+            suggested_fix: None,
+            details: Some(json!({
+                "from": mapping.from,
+                "to": mapping.to,
+            })),
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{
+        Constraints, EndpointConfig, Endpoints, HttpMethod, Mappings, ModelConfig, RequestMapping,
+        ResponseMapping, StrictMode, SupportFlags,
+    };
+
+    fn base_provider(code: Option<&str>) -> ProviderSpec {
+        ProviderSpec {
+            provider: "openai".into(),
+            models: vec![ModelConfig {
+                id: "gpt-4o".into(),
+            }],
+            endpoints: Endpoints {
+                chat: EndpointConfig {
+                    method: HttpMethod::Post,
+                    url: "https://example.com".into(),
+                    headers: Default::default(),
+                },
+            },
+            mappings: Mappings {
+                request: vec![RequestMapping {
+                    from: "messages[0]".into(),
+                    to: "body.system".into(),
+                    code: code.map(|c| c.to_string()),
+                    clamp: None,
+                }],
+                response: vec![ResponseMapping {
+                    from: "body.choices[0].message".into(),
+                    to: "prompt.response".into(),
+                }],
+            },
+            constraints: Constraints {
+                supports: SupportFlags {
+                    json_mode: true,
+                    tools: true,
+                },
+            },
+            auth: crate::auth::AuthScheme::Bearer {
+                token_env: "DUMMY".into(),
+            },
+        }
+    }
+
+    fn prompt_with_system(has_system: bool) -> PromptSpec {
+        let mut messages = vec![Message {
+            role: MessageRole::User,
+            content: "Hello".into(),
+        }];
+        if has_system {
+            messages.insert(
+                0,
+                Message {
+                    role: MessageRole::System,
+                    content: "System".into(),
+                },
+            );
+        }
+
+        PromptSpec {
+            version: "1".into(),
+            messages,
+            sampling: Default::default(),
+            response: Default::default(),
+            tools: Vec::new(),
+            tool_choice: None,
+            strict_mode: StrictMode::Warn,
+            metadata: Default::default(),
+        }
+    }
+
+    #[test]
+    fn records_relocate_when_mapping_present() {
+        let prompt = prompt_with_system(true);
+        let provider = base_provider(Some("Relocate"));
+        let mut report = LossinessReport::new(StrictMode::Warn);
+
+        detect_relocate(&prompt, &provider, &mut report);
+        assert!(report.is_lossy);
+        assert_eq!(report.entries.len(), 1);
+        assert_eq!(report.entries[0].code, LossinessCode::Relocate);
+    }
+
+    #[test]
+    fn no_entry_without_system_message() {
+        let prompt = prompt_with_system(false);
+        let provider = base_provider(Some("Relocate"));
+        let mut report = LossinessReport::new(StrictMode::Warn);
+
+        detect_relocate(&prompt, &provider, &mut report);
+        assert!(!report.is_lossy);
+    }
+
+    #[test]
+    fn no_entry_without_relocate_mapping() {
+        let prompt = prompt_with_system(true);
+        let provider = base_provider(None);
+        let mut report = LossinessReport::new(StrictMode::Warn);
+
+        detect_relocate(&prompt, &provider, &mut report);
+        assert!(!report.is_lossy);
+    }
+}

--- a/crates/specado-core/src/transformer/detect/unsupported.rs
+++ b/crates/specado-core/src/transformer/detect/unsupported.rs
@@ -1,0 +1,151 @@
+use crate::types::{
+    LossinessCode, LossinessEntry, LossinessLevel, LossinessReport, PromptSpec, ProviderSpec,
+    ResponseFormat,
+};
+use serde_json::json;
+
+pub fn detect_unsupported(
+    prompt: &PromptSpec,
+    provider: &ProviderSpec,
+    report: &mut LossinessReport,
+) {
+    if matches!(
+        prompt.response.format,
+        ResponseFormat::Json | ResponseFormat::JsonSchema
+    ) && !provider.constraints.supports.json_mode
+    {
+        report.add_entry(LossinessEntry {
+            code: LossinessCode::Unsupported,
+            level: LossinessLevel::Warn,
+            path: "response.format".to_string(),
+            reason: "Provider does not support native JSON mode".to_string(),
+            suggested_fix: Some(
+                "Use a provider with native JSON support or accept emulation".to_string(),
+            ),
+            details: Some(json!({
+                "requested": prompt.response.format,
+                "supported": false,
+            })),
+        });
+    }
+
+    if !prompt.tools.is_empty() && !provider.constraints.supports.tools {
+        report.add_entry(LossinessEntry {
+            code: LossinessCode::Unsupported,
+            level: LossinessLevel::Error,
+            path: "tools".to_string(),
+            reason: "Provider does not support tools".to_string(),
+            suggested_fix: Some("Remove tools or use a different provider".to_string()),
+            details: Some(json!({"tool_count": prompt.tools.len()})),
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{
+        Constraints, EndpointConfig, Endpoints, HttpMethod, Mappings, ModelConfig, RequestMapping,
+        ResponseConfig, ResponseMapping, StrictMode, SupportFlags, Tool,
+    };
+
+    fn provider_supports(json_mode: bool, tools: bool) -> ProviderSpec {
+        ProviderSpec {
+            provider: "fake".into(),
+            models: vec![ModelConfig { id: "m".into() }],
+            endpoints: Endpoints {
+                chat: EndpointConfig {
+                    method: HttpMethod::Post,
+                    url: "https://example.com".into(),
+                    headers: Default::default(),
+                },
+            },
+            mappings: Mappings {
+                request: vec![RequestMapping {
+                    from: "messages".into(),
+                    to: "body.messages".into(),
+                    code: None,
+                    clamp: None,
+                }],
+                response: vec![ResponseMapping {
+                    from: "body".into(),
+                    to: "response".into(),
+                }],
+            },
+            constraints: Constraints {
+                supports: SupportFlags { json_mode, tools },
+            },
+            auth: crate::auth::AuthScheme::Bearer {
+                token_env: "TOKEN".into(),
+            },
+        }
+    }
+
+    fn prompt_with_response(format: ResponseFormat, tool_count: usize) -> PromptSpec {
+        PromptSpec {
+            version: "1".into(),
+            messages: vec![crate::types::Message {
+                role: crate::types::MessageRole::User,
+                content: "Hello".into(),
+            }],
+            sampling: Default::default(),
+            response: ResponseConfig {
+                format,
+                ..Default::default()
+            },
+            tools: (0..tool_count)
+                .map(|i| Tool {
+                    name: format!("tool-{}", i),
+                    description: None,
+                    json_schema: serde_json::json!({"type": "object"}),
+                })
+                .collect(),
+            tool_choice: None,
+            strict_mode: StrictMode::Warn,
+            metadata: Default::default(),
+        }
+    }
+
+    #[test]
+    fn warns_when_json_mode_not_supported() {
+        let prompt = prompt_with_response(ResponseFormat::Json, 0);
+        let provider = provider_supports(false, true);
+        let mut report = LossinessReport::new(StrictMode::Warn);
+
+        detect_unsupported(&prompt, &provider, &mut report);
+        assert!(report.is_lossy);
+        assert_eq!(report.entries[0].code, LossinessCode::Unsupported);
+    }
+
+    #[test]
+    fn warns_for_json_schema_mode() {
+        let prompt = prompt_with_response(ResponseFormat::JsonSchema, 0);
+        let provider = provider_supports(false, true);
+        let mut report = LossinessReport::new(StrictMode::Warn);
+
+        detect_unsupported(&prompt, &provider, &mut report);
+        assert!(report.is_lossy);
+        assert_eq!(report.entries[0].path, "response.format");
+    }
+
+    #[test]
+    fn errors_when_tools_unsupported() {
+        let prompt = prompt_with_response(ResponseFormat::Text, 2);
+        let provider = provider_supports(true, false);
+        let mut report = LossinessReport::new(StrictMode::Warn);
+
+        detect_unsupported(&prompt, &provider, &mut report);
+        assert_eq!(report.entries.len(), 1);
+        assert_eq!(report.entries[0].level, LossinessLevel::Error);
+    }
+
+    #[test]
+    fn no_entries_when_supported() {
+        let prompt = prompt_with_response(ResponseFormat::Json, 1);
+        let provider = provider_supports(true, true);
+        let mut report = LossinessReport::new(StrictMode::Warn);
+
+        detect_unsupported(&prompt, &provider, &mut report);
+        assert!(!report.is_lossy);
+    }
+}

--- a/crates/specado-core/src/transformer/mod.rs
+++ b/crates/specado-core/src/transformer/mod.rs
@@ -1,0 +1,1 @@
+pub mod detect;


### PR DESCRIPTION
## Summary
- add clamp detector to enforce numeric ranges and log lossiness (#34)
- detect relocated system prompts, unsupported capabilities, and dropped parameters (#35-#37)
- expose the detect module barrel so transformer code can import helpers (#33)

## Testing
- cargo test -p specado-core

Closes #34
Closes #35
Closes #36
Closes #37
Closes #33