### PR TITLE
feat: add core resilience primitives

### DIFF
--- a/crates/specado-core/src/circuit_breaker.rs
+++ b/crates/specado-core/src/circuit_breaker.rs
@@ -1,0 +1,175 @@
+use crate::error::{Error, Result};
+use std::future::Future;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
+
+#[derive(Debug)]
+pub struct CircuitBreaker {
+    state: Arc<Mutex<CircuitState>>,
+    failure_threshold: usize,
+    timeout: Duration,
+    half_open_max_requests: usize,
+}
+
+#[derive(Debug)]
+enum CircuitState {
+    Closed {
+        failure_count: usize,
+    },
+    Open {
+        opened_at: Instant,
+    },
+    HalfOpen {
+        trial_count: usize,
+        success_count: usize,
+    },
+}
+
+impl CircuitBreaker {
+    pub fn new(failure_threshold: usize, timeout: Duration, half_open_max_requests: usize) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(CircuitState::Closed { failure_count: 0 })),
+            failure_threshold: failure_threshold.max(1),
+            timeout,
+            half_open_max_requests: half_open_max_requests.max(1),
+        }
+    }
+
+    pub async fn call<F, Fut, T>(&self, operation: F) -> Result<T>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<T>> + Send,
+        T: Send,
+    {
+        self.before_call().await?;
+        let outcome = operation().await;
+        match outcome {
+            Ok(value) => {
+                self.on_success().await;
+                Ok(value)
+            }
+            Err(err) => {
+                self.on_failure().await;
+                Err(err)
+            }
+        }
+    }
+
+    async fn before_call(&self) -> Result<()> {
+        let mut state = self.state.lock().await;
+        loop {
+            match &mut *state {
+                CircuitState::Closed { .. } => {
+                    break;
+                }
+                CircuitState::Open { opened_at } => {
+                    if opened_at.elapsed() >= self.timeout {
+                        *state = CircuitState::HalfOpen {
+                            trial_count: 0,
+                            success_count: 0,
+                        };
+                        continue;
+                    } else {
+                        return Err(Error::CircuitBreakerOpen);
+                    }
+                }
+                CircuitState::HalfOpen { trial_count, .. } => {
+                    if *trial_count >= self.half_open_max_requests {
+                        return Err(Error::CircuitBreakerHalfOpen);
+                    }
+                    *trial_count += 1;
+                    break;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn on_success(&self) {
+        let mut state = self.state.lock().await;
+        match &mut *state {
+            CircuitState::Closed { failure_count } => {
+                *failure_count = 0;
+            }
+            CircuitState::HalfOpen { success_count, .. } => {
+                *success_count += 1;
+                if *success_count >= self.half_open_max_requests {
+                    *state = CircuitState::Closed { failure_count: 0 };
+                }
+            }
+            CircuitState::Open { .. } => {
+                *state = CircuitState::Closed { failure_count: 0 };
+            }
+        }
+    }
+
+    async fn on_failure(&self) {
+        let mut state = self.state.lock().await;
+        match &mut *state {
+            CircuitState::Closed { failure_count } => {
+                *failure_count += 1;
+                if *failure_count >= self.failure_threshold {
+                    *state = CircuitState::Open {
+                        opened_at: Instant::now(),
+                    };
+                }
+            }
+            CircuitState::HalfOpen { .. } => {
+                *state = CircuitState::Open {
+                    opened_at: Instant::now(),
+                };
+            }
+            CircuitState::Open { .. } => {}
+        }
+    }
+}
+
+impl Default for CircuitBreaker {
+    fn default() -> Self {
+        Self::new(5, Duration::from_secs(30), 3)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::Error;
+
+    #[tokio::test]
+    async fn opens_after_threshold_failures() {
+        let breaker = CircuitBreaker::new(2, Duration::from_secs(30), 1);
+
+        assert!(breaker
+            .call(|| async { Err::<(), _>(Error::Transform("fail".into())) })
+            .await
+            .is_err());
+        assert!(breaker
+            .call(|| async { Err::<(), _>(Error::Transform("fail".into())) })
+            .await
+            .is_err());
+
+        let err = breaker
+            .call(|| async { Ok::<(), Error>(()) })
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::CircuitBreakerOpen));
+    }
+
+    #[tokio::test]
+    async fn half_open_allows_recovery() {
+        let breaker = CircuitBreaker::new(1, Duration::from_millis(0), 1);
+
+        let _ = breaker
+            .call(|| async { Err::<(), _>(Error::Transform("fail".into())) })
+            .await;
+
+        // timeout is zero so breaker should move to half-open and allow a probe request
+        let result = breaker.call(|| async { Ok::<_, Error>("success") }).await;
+        assert!(result.is_ok());
+
+        // subsequent requests should flow normally
+        let result = breaker.call(|| async { Ok::<_, Error>("again") }).await;
+        assert!(result.is_ok());
+    }
+}

--- a/crates/specado-core/src/http/client.rs
+++ b/crates/specado-core/src/http/client.rs
@@ -1,0 +1,28 @@
+use once_cell::sync::Lazy;
+use reqwest::Client;
+use std::time::Duration;
+
+static HTTP_CLIENT: Lazy<Client> = Lazy::new(|| {
+    Client::builder()
+        .timeout(Duration::from_secs(60))
+        .pool_max_idle_per_host(10)
+        .connect_timeout(Duration::from_secs(10))
+        .build()
+        .expect("Failed to create HTTP client")
+});
+
+pub fn get_client() -> &'static Client {
+    &HTTP_CLIENT
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_same_instance() {
+        let client_a = get_client() as *const Client;
+        let client_b = get_client() as *const Client;
+        assert_eq!(client_a, client_b);
+    }
+}

--- a/crates/specado-core/src/http/mod.rs
+++ b/crates/specado-core/src/http/mod.rs
@@ -1,0 +1,3 @@
+pub mod client;
+
+pub use client::get_client;

--- a/crates/specado-core/src/lib.rs
+++ b/crates/specado-core/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod auth;
 pub mod error;
 pub mod http;
+pub mod retry;
 pub mod transformer;
 pub mod types;
 

--- a/crates/specado-core/src/lib.rs
+++ b/crates/specado-core/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 pub mod auth;
+pub mod circuit_breaker;
 pub mod error;
 pub mod http;
 pub mod retry;

--- a/crates/specado-core/src/lib.rs
+++ b/crates/specado-core/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod auth;
 pub mod error;
+pub mod http;
 pub mod transformer;
 pub mod types;
 

--- a/crates/specado-core/src/lib.rs
+++ b/crates/specado-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod circuit_breaker;
 pub mod error;
 pub mod http;
 pub mod retry;
+pub mod router;
 pub mod transformer;
 pub mod types;
 

--- a/crates/specado-core/src/retry.rs
+++ b/crates/specado-core/src/retry.rs
@@ -23,17 +23,20 @@ impl RetryPolicy {
     }
 
     fn backoff_delay(&self, attempt: usize) -> Duration {
-        if attempt == 0 {
-            return Duration::from_secs(0);
+        if attempt <= 1 {
+            return self.base_delay.min(self.max_delay);
         }
 
         let mut delay = self.base_delay;
-        for _ in 1..=attempt.saturating_sub(1) {
-            delay = delay.mul_f32(2.0);
+        for _ in 1..attempt {
+            delay = delay
+                .checked_mul(2)
+                .unwrap_or(self.max_delay);
             if delay >= self.max_delay {
                 return self.max_delay;
             }
         }
+
         delay.min(self.max_delay)
     }
 

--- a/crates/specado-core/src/retry.rs
+++ b/crates/specado-core/src/retry.rs
@@ -1,0 +1,140 @@
+use crate::error::Result;
+use std::future::Future;
+use std::time::Duration;
+
+#[derive(Debug, Clone)]
+pub struct RetryPolicy {
+    max_attempts: usize,
+    base_delay: Duration,
+    max_delay: Duration,
+}
+
+impl RetryPolicy {
+    pub fn new(max_attempts: usize, base_delay: Duration, max_delay: Duration) -> Self {
+        Self {
+            max_attempts: max_attempts.max(1),
+            base_delay,
+            max_delay,
+        }
+    }
+
+    pub fn max_attempts(&self) -> usize {
+        self.max_attempts
+    }
+
+    fn backoff_delay(&self, attempt: usize) -> Duration {
+        if attempt == 0 {
+            return Duration::from_secs(0);
+        }
+
+        let mut delay = self.base_delay;
+        for _ in 1..=attempt.saturating_sub(1) {
+            delay = delay.mul_f32(2.0);
+            if delay >= self.max_delay {
+                return self.max_delay;
+            }
+        }
+        delay.min(self.max_delay)
+    }
+
+    pub async fn execute<F, Fut, T>(&self, mut operation: F) -> Result<T>
+    where
+        F: FnMut() -> Fut,
+        Fut: Future<Output = Result<T>> + Send,
+        T: Send,
+    {
+        let mut attempt = 0;
+        loop {
+            attempt += 1;
+            match operation().await {
+                Ok(value) => return Ok(value),
+                Err(err) => {
+                    if attempt >= self.max_attempts {
+                        return Err(err);
+                    }
+                    let delay = self.backoff_delay(attempt);
+                    if !delay.is_zero() {
+                        tokio::time::sleep(delay).await;
+                    } else {
+                        tokio::task::yield_now().await;
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_attempts: 3,
+            base_delay: Duration::from_millis(100),
+            max_delay: Duration::from_secs(10),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::Error;
+    use std::sync::{Arc, Mutex};
+
+    #[tokio::test]
+    async fn retries_until_success() {
+        let policy = RetryPolicy::new(3, Duration::from_millis(0), Duration::from_millis(0));
+        let attempts = Arc::new(Mutex::new(0));
+        let result = policy
+            .execute({
+                let attempts = attempts.clone();
+                move || {
+                    let attempts = attempts.clone();
+                    Box::pin(async move {
+                        let mut guard = attempts.lock().unwrap();
+                        *guard += 1;
+                        if *guard < 2 {
+                            Err(Error::Transform("fail".into()))
+                        } else {
+                            Ok("ok")
+                        }
+                    })
+                }
+            })
+            .await;
+
+        assert_eq!(*attempts.lock().unwrap(), 2);
+        assert_eq!(result.unwrap(), "ok");
+    }
+
+    #[tokio::test]
+    async fn stops_after_max_attempts() {
+        let policy = RetryPolicy::new(2, Duration::from_millis(0), Duration::from_millis(0));
+        let attempts = Arc::new(Mutex::new(0));
+        let result: Result<()> = policy
+            .execute({
+                let attempts = attempts.clone();
+                move || {
+                    let attempts = attempts.clone();
+                    Box::pin(async move {
+                        let mut guard = attempts.lock().unwrap();
+                        *guard += 1;
+                        Err(Error::Transform("still failing".into()))
+                    })
+                }
+            })
+            .await;
+
+        assert!(result.is_err());
+        assert_eq!(*attempts.lock().unwrap(), 2);
+    }
+
+    #[test]
+    fn backoff_caps_at_max_delay() {
+        let policy = RetryPolicy::new(5, Duration::from_millis(100), Duration::from_millis(350));
+
+        assert_eq!(policy.backoff_delay(1), Duration::from_millis(100));
+        assert_eq!(policy.backoff_delay(2), Duration::from_millis(200));
+        assert_eq!(policy.backoff_delay(3), Duration::from_millis(350));
+        assert_eq!(policy.backoff_delay(4), Duration::from_millis(350));
+    }
+}

--- a/crates/specado-core/src/router/mod.rs
+++ b/crates/specado-core/src/router/mod.rs
@@ -1,0 +1,5 @@
+pub mod primary_fallback;
+pub mod traits;
+
+pub use primary_fallback::{BoxedExecutor, PrimaryFallbackRouter};
+pub use traits::Router;

--- a/crates/specado-core/src/router/primary_fallback.rs
+++ b/crates/specado-core/src/router/primary_fallback.rs
@@ -1,0 +1,129 @@
+use crate::error::{Error, Result};
+use crate::router::traits::Router;
+use crate::types::{PromptSpec, UniformResponse};
+use async_trait::async_trait;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+pub type BoxedExecutor = Arc<dyn Fn(PromptSpec, String) -> ExecutorFuture + Send + Sync>;
+
+pub type ExecutorFuture = Pin<Box<dyn Future<Output = Result<UniformResponse>> + Send>>;
+
+pub struct PrimaryFallbackRouter {
+    primary: String,
+    fallbacks: Vec<String>,
+    executor: BoxedExecutor,
+}
+
+impl PrimaryFallbackRouter {
+    pub fn new(
+        primary: impl Into<String>,
+        fallbacks: Vec<String>,
+        executor: BoxedExecutor,
+    ) -> Self {
+        Self {
+            primary: primary.into(),
+            fallbacks,
+            executor,
+        }
+    }
+}
+
+#[async_trait]
+impl Router for PrimaryFallbackRouter {
+    async fn route(&self, prompt: PromptSpec) -> Result<UniformResponse> {
+        let executor = &self.executor;
+        let mut last_error: Option<Error> = None;
+
+        for provider in std::iter::once(&self.primary).chain(self.fallbacks.iter()) {
+            let provider_path = provider.clone();
+            match executor(prompt.clone(), provider_path).await {
+                Ok(response) => return Ok(response),
+                Err(err) => {
+                    last_error = Some(err);
+                }
+            }
+        }
+
+        Err(last_error.unwrap_or_else(|| {
+            Error::Config("No providers configured for PrimaryFallbackRouter".into())
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::Error;
+    use crate::types::{Extensions, FinishReason, LossinessReport, StrictMode};
+
+    fn sample_response(model: &str) -> UniformResponse {
+        UniformResponse {
+            content: "hi".into(),
+            tool_calls: Vec::new(),
+            finish_reason: FinishReason::Stop,
+            model: model.into(),
+            provider_used: model.into(),
+            usage: None,
+            extensions: Extensions {
+                lossiness: LossinessReport::new(StrictMode::Warn),
+            },
+        }
+    }
+
+    fn make_prompt() -> PromptSpec {
+        PromptSpec {
+            version: "1".into(),
+            messages: Vec::new(),
+            sampling: Default::default(),
+            response: Default::default(),
+            tools: Vec::new(),
+            tool_choice: None,
+            strict_mode: StrictMode::Warn,
+            metadata: Default::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn uses_primary_when_successful() {
+        let executor: BoxedExecutor = Arc::new(|prompt, provider| {
+            Box::pin(async move {
+                let _ = prompt;
+                Ok(sample_response(&provider))
+            })
+        });
+
+        let router = PrimaryFallbackRouter::new("primary", vec!["fallback".into()], executor);
+        let response = router.route(make_prompt()).await.unwrap();
+        assert_eq!(response.provider_used, "primary");
+    }
+
+    #[tokio::test]
+    async fn falls_back_when_primary_fails() {
+        let failures = Arc::new(std::sync::Mutex::new(0));
+        let executor: BoxedExecutor = {
+            let failures = failures.clone();
+            Arc::new(move |prompt, provider| {
+                let failures = failures.clone();
+                Box::pin(async move {
+                    let _ = prompt;
+                    if provider == "primary" {
+                        *failures.lock().unwrap() += 1;
+                        Err(Error::Provider {
+                            provider: provider.clone(),
+                            kind: crate::error::ProviderErrorKind::ServerError,
+                        })
+                    } else {
+                        Ok(sample_response(&provider))
+                    }
+                })
+            })
+        };
+
+        let router = PrimaryFallbackRouter::new("primary", vec!["secondary".into()], executor);
+        let response = router.route(make_prompt()).await.unwrap();
+        assert_eq!(response.provider_used, "secondary");
+        assert_eq!(*failures.lock().unwrap(), 1);
+    }
+}

--- a/crates/specado-core/src/router/traits.rs
+++ b/crates/specado-core/src/router/traits.rs
@@ -1,0 +1,8 @@
+use crate::error::Result;
+use crate::types::{PromptSpec, UniformResponse};
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait Router: Send + Sync {
+    async fn route(&self, prompt: PromptSpec) -> Result<UniformResponse>;
+}


### PR DESCRIPTION
## Summary
- introduce an HTTP client singleton exposing `get_client()` for reuse (#38)
- add retry policy with capped exponential backoff and unit coverage (#40)
- implement a circuit breaker supporting closed/open/half-open states (#39)
- provide routing trait and primary-fallback router with injectable executor (#41)

## Testing
- cargo test -p specado-core

Closes #38
Closes #40
Closes #39
Closes #41