### PR TITLE
feat: add specado CLI entry points

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,10 +47,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "ascii-canvas"
@@ -69,6 +119,22 @@ checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "assert_cmd"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -358,6 +424,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eeab4423108c5d7c744f4d234de88d18d636100093ae04caf4825134b9c3a32"
 
 [[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -445,8 +523,22 @@ version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -454,6 +546,22 @@ name = "clap_lex"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -532,6 +640,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,6 +676,12 @@ dependencies = [
  "quote",
  "syn 2.0.106",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"
@@ -600,7 +720,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -658,6 +778,15 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "fluent-uri"
@@ -830,6 +959,12 @@ name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1183,6 +1318,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,6 +1535,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1486,6 +1633,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "oorandom"
@@ -1647,6 +1800,36 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1934,7 +2117,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -2189,6 +2372,20 @@ dependencies = [
 [[package]]
 name = "specado-cli"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "assert_cmd",
+ "clap",
+ "colored",
+ "httpmock",
+ "predicates",
+ "serde_json",
+ "serde_yaml",
+ "specado-core",
+ "specado-schemas",
+ "tempfile",
+ "tokio",
+]
 
 [[package]]
 name = "specado-core"
@@ -2251,6 +2448,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2308,7 +2511,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -2321,6 +2524,12 @@ dependencies = [
  "rustversion",
  "winapi",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -2571,6 +2780,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2608,6 +2823,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"
@@ -2775,7 +2999,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -2796,7 +3020,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2805,7 +3029,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.4",
 ]
 
 [[package]]
@@ -2823,14 +3056,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2840,10 +3090,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2852,10 +3114,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2864,10 +3138,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2876,10 +3162,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,11 @@ jsonschema = "0.26.1"
 serde_json_path = "0.7.2"
 clap = { version = "4.5.23", features = ["derive", "env"] }
 colored = "2.1.0"
+anyhow = "1.0"
+assert_cmd = "2.0"
+predicates = "3.1"
+httpmock = "0.7"
+tempfile = "3.10"
 specado-core = { path = "crates/specado-core" }
 specado-schemas = { path = "crates/specado-schemas" }
 

--- a/crates/specado-cli/Cargo.toml
+++ b/crates/specado-cli/Cargo.toml
@@ -3,8 +3,26 @@ name = "specado-cli"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-repository.workspace = true
-rust-version.workspace = true
 publish = false
 
+[[bin]]
+name = "specado"
+path = "src/main.rs"
+
 [dependencies]
+anyhow = "1.0"
+clap.workspace = true
+colored.workspace = true
+serde_json.workspace = true
+serde_yaml.workspace = true
+specado-core.workspace = true
+specado-schemas.workspace = true
+tokio.workspace = true
+
+[dev-dependencies]
+assert_cmd = "2.0"
+predicates = "3.1"
+httpmock = "0.7"
+serde_json.workspace = true
+serde_yaml.workspace = true
+tempfile = "3.10"

--- a/crates/specado-cli/src/main.rs
+++ b/crates/specado-cli/src/main.rs
@@ -1,3 +1,185 @@
-fn main() {
-    println!("Specado CLI scaffolding – functionality coming soon.");
+use anyhow::{anyhow, Context, Result};
+use clap::{Parser, Subcommand};
+use colored::*;
+use specado_core::{
+    execute, translate as core_translate, LossinessLevel, LossinessReport, PromptSpec, ProviderSpec,
+};
+use specado_schemas::get_validator;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process;
+
+#[derive(Parser)]
+#[command(name = "specado")]
+#[command(version, about = "Spec-driven LLM abstraction", long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Validate a prompt or provider specification against the schemas
+    Validate {
+        #[arg(long)]
+        spec: PathBuf,
+    },
+    /// Preview the translated provider payload alongside the lossiness report
+    Preview {
+        #[arg(long)]
+        prompt: PathBuf,
+        #[arg(long)]
+        provider: PathBuf,
+    },
+    /// Execute the prompt against the provider and print the normalized response
+    Run {
+        #[arg(long)]
+        prompt: PathBuf,
+        #[arg(long)]
+        provider: PathBuf,
+    },
+}
+
+#[tokio::main]
+async fn main() {
+    let cli = Cli::parse();
+
+    let result = match cli.command {
+        Commands::Validate { spec } => validate_command(spec).await,
+        Commands::Preview { prompt, provider } => preview_command(prompt, provider).await,
+        Commands::Run { prompt, provider } => run_command(prompt, provider).await,
+    };
+
+    if let Err(err) = result {
+        eprintln!("{} {}", "Error:".red().bold(), err);
+        process::exit(1);
+    }
+}
+
+async fn validate_command(spec_path: PathBuf) -> Result<()> {
+    let content = fs::read_to_string(&spec_path)
+        .with_context(|| format!("Failed to read spec file: {}", spec_path.display()))?;
+
+    let value = parse_to_json_value(&content, &spec_path)?;
+    let validator = get_validator();
+
+    let looks_provider = value.get("provider").is_some()
+        || value.get("endpoints").is_some()
+        || value.get("auth").is_some();
+
+    if looks_provider {
+        validator
+            .validate_provider(&value)
+            .map_err(|e| anyhow!("Provider spec invalid: {}", e))?;
+        println!("{} Provider spec is valid", "✓".green().bold());
+    } else {
+        validator
+            .validate_prompt(&value)
+            .map_err(|e| anyhow!("Prompt spec invalid: {}", e))?;
+        println!("{} Prompt spec is valid", "✓".green().bold());
+    }
+
+    Ok(())
+}
+
+async fn preview_command(prompt_path: PathBuf, provider_path: PathBuf) -> Result<()> {
+    let prompt = load_prompt_spec(&prompt_path)?;
+    let provider = load_provider_spec(&provider_path)?;
+
+    let (translated, lossiness) = core_translate(&prompt, &provider)?;
+
+    println!("{}", "=== Translated Request ===".cyan().bold());
+    println!("{}", serde_json::to_string_pretty(&translated)?);
+    println!();
+
+    print_lossiness(&lossiness);
+
+    Ok(())
+}
+
+async fn run_command(prompt_path: PathBuf, provider_path: PathBuf) -> Result<()> {
+    let prompt = load_prompt_spec(&prompt_path)?;
+    let response = execute(
+        prompt,
+        provider_path
+            .to_str()
+            .ok_or_else(|| anyhow!("Provider path contains invalid UTF-8"))?,
+    )
+    .await?;
+
+    println!("{}", serde_json::to_string_pretty(&response)?);
+
+    Ok(())
+}
+
+fn parse_to_json_value(content: &str, path: &Path) -> Result<serde_json::Value> {
+    let ext = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+
+    if ext == "yaml" || ext == "yml" {
+        Ok(serde_yaml::from_str(content)?)
+    } else {
+        match serde_json::from_str(content) {
+            Ok(value) => Ok(value),
+            Err(_) => Ok(serde_yaml::from_str(content)?),
+        }
+    }
+}
+
+fn load_prompt_spec(path: &Path) -> Result<PromptSpec> {
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read prompt spec: {}", path.display()))?;
+
+    match serde_json::from_str(&content) {
+        Ok(spec) => Ok(spec),
+        Err(json_err) => serde_yaml::from_str(&content).map_err(|yaml_err| {
+            anyhow!("Failed to parse prompt spec as JSON ({json_err}) or YAML ({yaml_err})")
+        }),
+    }
+}
+
+fn load_provider_spec(path: &Path) -> Result<ProviderSpec> {
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read provider spec: {}", path.display()))?;
+
+    match serde_yaml::from_str(&content) {
+        Ok(spec) => Ok(spec),
+        Err(yaml_err) => serde_json::from_str(&content).map_err(|json_err| {
+            anyhow!("Failed to parse provider spec as YAML ({yaml_err}) or JSON ({json_err})")
+        }),
+    }
+}
+
+fn print_lossiness(report: &LossinessReport) {
+    println!("{}", "=== Lossiness Report ===".yellow().bold());
+    if report.is_lossy {
+        for entry in &report.entries {
+            let level = match entry.level {
+                LossinessLevel::Info => "INFO".blue(),
+                LossinessLevel::Warn => "WARN".yellow(),
+                LossinessLevel::Error => "ERROR".red(),
+            };
+            println!(
+                "{} [{:?}] {} ({})",
+                level, entry.code, entry.reason, entry.path
+            );
+            if let Some(details) = &entry.details {
+                println!("    details: {}", details.to_string());
+            }
+            if let Some(fix) = &entry.suggested_fix {
+                println!("    suggested fix: {}", fix);
+            }
+        }
+        if !report.omissions.is_empty() {
+            println!("{}", "Omissions:".yellow().bold());
+            for omission in &report.omissions {
+                println!("  - {}", omission);
+            }
+        }
+    } else {
+        println!("{} No lossiness detected", "✓".green().bold());
+    }
 }

--- a/crates/specado-cli/tests/cli.rs
+++ b/crates/specado-cli/tests/cli.rs
@@ -1,0 +1,174 @@
+use assert_cmd::Command;
+use httpmock::prelude::*;
+use predicates::prelude::*;
+use serde_json::json;
+use std::fs::write;
+use tempfile::TempDir;
+
+fn write_file(dir: &TempDir, name: &str, contents: &str) -> std::path::PathBuf {
+    let path = dir.path().join(name);
+    write(&path, contents).expect("write file");
+    path
+}
+
+fn sample_prompt_json() -> serde_json::Value {
+    json!({
+        "version": "1",
+        "messages": [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"}
+        ],
+        "sampling": {
+            "temperature": 0.5,
+            "top_k": 10
+        }
+    })
+}
+
+fn sample_provider_yaml(url: &str, token_env: &str) -> String {
+    format!(
+        r#"provider: test
+auth:
+  type: bearer
+  token_env: {token_env}
+models:
+  - id: test-model
+endpoints:
+  chat:
+    method: POST
+    url: {url}
+    headers:
+      content-type: application/json
+mappings:
+  request:
+    - from: $.messages
+      to: $.body.messages
+    - from: $.sampling.temperature
+      to: $.body.temperature
+      clamp: [0.0, 1.0]
+  response:
+    - from: $.data.content
+      to: content
+    - from: $.data.finish_reason
+      to: finish_reason
+constraints:
+  supports:
+    json_mode: true
+    tools: true
+"#,
+        url = url,
+        token_env = token_env
+    )
+}
+
+#[test]
+fn validate_prompt_and_provider() {
+    let dir = TempDir::new().expect("temp dir");
+    let prompt_path = write_file(
+        &dir,
+        "prompt.json",
+        &serde_json::to_string_pretty(&sample_prompt_json()).unwrap(),
+    );
+    let provider_path = write_file(
+        &dir,
+        "provider.yaml",
+        sample_provider_yaml("https://example.com", "SPECADO_CLI_VALID_TOKEN").as_str(),
+    );
+
+    // Prompt should validate
+    let mut cmd = Command::cargo_bin("specado").expect("binary");
+    cmd.env("NO_COLOR", "1")
+        .arg("validate")
+        .arg("--spec")
+        .arg(&prompt_path);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Prompt spec is valid"));
+
+    // Provider should validate
+    let mut cmd = Command::cargo_bin("specado").expect("binary");
+    cmd.env("NO_COLOR", "1")
+        .arg("validate")
+        .arg("--spec")
+        .arg(&provider_path);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Provider spec is valid"));
+}
+
+#[test]
+fn preview_outputs_translated_request_and_lossiness() {
+    let dir = TempDir::new().expect("temp dir");
+    let prompt_path = write_file(
+        &dir,
+        "prompt.json",
+        &serde_json::to_string_pretty(&sample_prompt_json()).unwrap(),
+    );
+    let provider_path = write_file(
+        &dir,
+        "provider.yaml",
+        sample_provider_yaml("https://example.com", "SPECADO_UNUSED").as_str(),
+    );
+
+    let mut cmd = Command::cargo_bin("specado").expect("binary");
+    cmd.env("NO_COLOR", "1")
+        .arg("preview")
+        .arg("--prompt")
+        .arg(&prompt_path)
+        .arg("--provider")
+        .arg(&provider_path);
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("=== Translated Request ==="))
+        .stdout(predicate::str::contains("=== Lossiness Report ==="));
+}
+
+#[test]
+fn run_executes_against_provider() {
+    let dir = TempDir::new().expect("temp dir");
+    let prompt_path = write_file(
+        &dir,
+        "prompt.json",
+        &serde_json::to_string_pretty(&sample_prompt_json()).unwrap(),
+    );
+
+    let server = MockServer::start();
+    let token_env = "SPECADO_CLI_TOKEN";
+    std::env::set_var(token_env, "cli-secret");
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/chat")
+            .header("authorization", "Bearer cli-secret");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "data": {
+                    "content": "hi from cli",
+                    "finish_reason": "stop"
+                }
+            }));
+    });
+
+    let provider_path = write_file(
+        &dir,
+        "provider.yaml",
+        sample_provider_yaml(&server.url("/chat"), token_env).as_str(),
+    );
+
+    let mut cmd = Command::cargo_bin("specado").expect("binary");
+    cmd.env("NO_COLOR", "1")
+        .arg("run")
+        .arg("--prompt")
+        .arg(&prompt_path)
+        .arg("--provider")
+        .arg(&provider_path);
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("hi from cli"));
+
+    mock.assert_hits(1);
+    std::env::remove_var(token_env);
+}


### PR DESCRIPTION
## Summary
- scaffold `specado` binary with validate/preview/run subcommands calling core orchestrations (#42)
- auto-detect prompt vs provider specs for `validate` and pretty-print lossiness reports for `preview`
- integration tests cover CLI commands via assert_cmd/httpmock/tempfile helpers

## Testing
- cargo test --workspace

Closes #42