### PR TITLE
feat: add PyO3 bindings for specado-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1271,6 +1271,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
 name = "inventory"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1491,6 +1497,15 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -1778,6 +1793,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1841,6 +1862,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyo3"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
+dependencies = [
+ "cfg-if",
+ "indoc",
+ "libc",
+ "memoffset",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "pythonize"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcf491425978bd889015d5430f6473d91bdfa2097262f1e731aadcf6c2113e"
+dependencies = [
+ "pyo3",
+ "serde",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1892,7 +1986,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.0",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2418,6 +2512,15 @@ version = "0.1.0"
 [[package]]
 name = "specado-py"
 version = "0.1.0"
+dependencies = [
+ "once_cell",
+ "pyo3",
+ "pyo3-build-config",
+ "pythonize",
+ "serde_json",
+ "specado-core",
+ "tokio",
+]
 
 [[package]]
 name = "specado-schemas"
@@ -2500,6 +2603,12 @@ dependencies = [
  "quote",
  "syn 2.0.106",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
@@ -2748,6 +2857,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unindent"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ assert_cmd = "2.0"
 predicates = "3.1"
 httpmock = "0.7"
 tempfile = "3.10"
+pythonize = "0.22.0"
+pyo3 = { version = "0.22.6", features = ["extension-module", "abi3-py39"] }
 specado-core = { path = "crates/specado-core" }
 specado-schemas = { path = "crates/specado-schemas" }
 

--- a/crates/specado-py/Cargo.toml
+++ b/crates/specado-py/Cargo.toml
@@ -3,12 +3,19 @@ name = "specado-py"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-repository.workspace = true
-rust-version.workspace = true
 publish = false
 
 [lib]
-name = "specado_py"
-crate-type = ["lib"]
+name = "specado"
+crate-type = ["cdylib"]
 
 [dependencies]
+specado-core.workspace = true
+pyo3 = { version = "0.22.6", features = ["extension-module", "abi3-py39"] }
+tokio.workspace = true
+serde_json.workspace = true
+pythonize = "0.22.0"
+once_cell.workspace = true
+
+[build-dependencies]
+pyo3-build-config = "0.22.6"

--- a/crates/specado-py/src/lib.rs
+++ b/crates/specado-py/src/lib.rs
@@ -1,4 +1,93 @@
-#![allow(dead_code)]
+use once_cell::sync::Lazy;
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+use pyo3::wrap_pyfunction;
+use pythonize::{depythonize, pythonize};
+use specado_core::{
+    execute, translate as core_translate, PromptSpec, ProviderSpec, UniformResponse,
+};
+use std::sync::Arc;
+use tokio::runtime::{Builder, Runtime};
 
-/// Placeholder for the eventual PyO3 bindings.
-pub fn initialize() {}
+static RUNTIME: Lazy<Arc<Runtime>> = Lazy::new(|| {
+    Arc::new(
+        Builder::new_multi_thread()
+            .enable_all()
+            .thread_name("specado-py")
+            .build()
+            .expect("Failed to create Tokio runtime"),
+    )
+});
+
+#[pyclass]
+struct Client {
+    provider_path: String,
+}
+
+#[pymethods]
+impl Client {
+    #[new]
+    fn new(provider_path: String) -> PyResult<Self> {
+        Ok(Self { provider_path })
+    }
+
+    fn complete(&self, py: Python<'_>, prompt: &Bound<'_, PyDict>) -> PyResult<PyObject> {
+        let prompt_json = depythonize::<serde_json::Value>(prompt)?;
+        let prompt_spec: PromptSpec = serde_json::from_value(prompt_json)
+            .map_err(|e| PyValueError::new_err(format!("Invalid prompt spec: {e}")))?;
+        let provider_path = self.provider_path.clone();
+
+        let runtime = RUNTIME.clone();
+        let response: UniformResponse = py
+            .allow_threads(|| {
+                runtime.block_on(async { execute(prompt_spec, &provider_path).await })
+            })
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+
+        let response_json = serde_json::to_value(&response)
+            .map_err(|e| PyValueError::new_err(format!("Failed to encode response: {e}")))?;
+
+        Ok(pythonize(py, &response_json)?.into_py(py))
+    }
+}
+
+#[pyfunction]
+fn translate(
+    py: Python<'_>,
+    prompt: &Bound<'_, PyDict>,
+    provider: &Bound<'_, PyDict>,
+) -> PyResult<(PyObject, PyObject)> {
+    let prompt_json = depythonize::<serde_json::Value>(prompt)?;
+    let provider_json = depythonize::<serde_json::Value>(provider)?;
+
+    let prompt_spec: PromptSpec = serde_json::from_value(prompt_json)
+        .map_err(|e| PyValueError::new_err(format!("Invalid prompt spec: {e}")))?;
+    let provider_spec: ProviderSpec = serde_json::from_value(provider_json)
+        .map_err(|e| PyValueError::new_err(format!("Invalid provider spec: {e}")))?;
+
+    let (translated, lossiness) = core_translate(&prompt_spec, &provider_spec)
+        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+
+    let translated_py = pythonize(py, &translated)?.into_py(py);
+    let lossiness_py = pythonize(py, &lossiness)?.into_py(py);
+    Ok((translated_py, lossiness_py))
+}
+
+#[pymodule]
+fn specado(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<Client>()?;
+    m.add_function(wrap_pyfunction!(translate, m)?)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runtime_initializes_once() {
+        let _runtime = RUNTIME.clone();
+        assert!(tokio::runtime::Handle::try_current().is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- configure `specado-py` as a PyO3 cdylib exposing `Client` and `translate` helpers (#43)
- embed a shared Tokio runtime for async execution and bridge serde <-> python via pythonize
- add workspace dependencies and a basic runtime initialization test

## Testing
- cargo test -p specado-py
- cargo test --workspace