### PR TITLE
feat: package Python API with OpenAI compat layer

### DIFF
--- a/crates/specado-py/Cargo.toml
+++ b/crates/specado-py/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 publish = false
 
 [lib]
-name = "specado"
+name = "_native"
 crate-type = ["cdylib"]
 
 [dependencies]

--- a/crates/specado-py/src/lib.rs
+++ b/crates/specado-py/src/lib.rs
@@ -75,7 +75,7 @@ fn translate(
 }
 
 #[pymodule]
-fn specado(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
+fn _native(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Client>()?;
     m.add_function(wrap_pyfunction!(translate, m)?)?;
     Ok(())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,23 @@
 [build-system]
-requires = ["maturin>=1.4"]
+requires = ["maturin>=1.7,<2.0"]
 build-backend = "maturin"
 
 [project]
 name = "specado"
 version = "0.1.0"
-description = "Specado Python bindings"
-readme = "README.md"
+description = "Spec-driven LLM abstraction library"
 requires-python = ">=3.9"
-authors = [{ name = "Specado" }]
-dependencies = []
+license = { text = "Apache-2.0" }
+classifiers = [
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
 
 [tool.maturin]
-features = []
+python-source = "python"
+module-name = "specado._native"
+manifest-path = "crates/specado-py/Cargo.toml"
+features = ["pyo3/extension-module"]

--- a/python/specado/__init__.py
+++ b/python/specado/__init__.py
@@ -1,3 +1,58 @@
-"""Specado Python bindings placeholder module."""
+from __future__ import annotations
 
-__all__ = []
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional
+
+from ._native import Client as _NativeClient
+
+__all__ = ["Client", "PromptSpec", "Message", "__version__"]
+__version__ = "0.1.0"
+
+
+@dataclass
+class Message:
+    role: str
+    content: str
+
+
+@dataclass
+class PromptSpec:
+    messages: List[Message]
+    sampling: Optional[Dict[str, float]] = None
+    strict_mode: str = "Warn"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "version": "1",
+            "messages": [
+                {"role": message.role, "content": message.content}
+                for message in self.messages
+            ],
+            "sampling": self.sampling or {},
+            "strict_mode": self.strict_mode,
+        }
+
+
+class Client:
+    """High-level Python wrapper around the native Specado client."""
+
+    def __init__(self, provider_path: str):
+        self._client = _NativeClient(provider_path)
+
+    def complete(self, prompt: PromptSpec | Dict[str, Any]) -> Dict[str, Any]:
+        if isinstance(prompt, PromptSpec):
+            payload = prompt.to_dict()
+        else:
+            payload = prompt
+        return self._client.complete(payload)
+
+    async def acomplete(self, prompt: PromptSpec | Dict[str, Any]) -> Dict[str, Any]:
+        from asyncio import get_running_loop
+
+        loop = get_running_loop()
+        return await loop.run_in_executor(None, self.complete, prompt)
+
+
+from . import compat  # noqa: E402
+
+__all__.append("compat")

--- a/python/specado/compat/__init__.py
+++ b/python/specado/compat/__init__.py
@@ -1,0 +1,3 @@
+from .openai import OpenAI
+
+__all__ = ["OpenAI"]

--- a/python/specado/compat/openai.py
+++ b/python/specado/compat/openai.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from .. import Client as SpecadoClient, Message as SpecadoMessage, PromptSpec
+
+
+@dataclass
+class Message:
+    role: str
+    content: str
+
+
+@dataclass
+class Choice:
+    message: Message
+    finish_reason: str
+
+
+@dataclass
+class ChatCompletion:
+    choices: List[Choice]
+
+
+class ChatCompletions:
+    def __init__(self, client: SpecadoClient):
+        self._client = client
+
+    def create(
+        self,
+        model: str,
+        messages: List[Dict[str, str]],
+        temperature: Optional[float] = None,
+        **_: Any,
+    ) -> ChatCompletion:
+        prompt = PromptSpec(
+            messages=[
+                SpecadoMessage(role=message["role"], content=message["content"])
+                for message in messages
+            ],
+            sampling={"temperature": temperature} if temperature is not None else None,
+        )
+
+        response = self._client.complete(prompt)
+        message = Message(role="assistant", content=response["content"])
+        choice = Choice(message=message, finish_reason=response["finish_reason"])
+        return ChatCompletion(choices=[choice])
+
+
+class Chat:
+    def __init__(self, client: SpecadoClient):
+        self.completions = ChatCompletions(client)
+
+
+class OpenAI:
+    def __init__(self, provider_path: str):
+        self._client = SpecadoClient(provider_path)
+        self.chat = Chat(self._client)

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[1]
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))

--- a/python/tests/test_openai_compat.py
+++ b/python/tests/test_openai_compat.py
@@ -1,0 +1,112 @@
+import json
+import os
+import socket
+import threading
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from specado import Client, Message, PromptSpec
+from specado.compat import OpenAI
+
+
+class _MockHandler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get("content-length", 0))
+        _ = self.rfile.read(length)
+        body = {
+            "data": {
+                "content": "hello from python",
+                "finish_reason": "stop",
+            }
+        }
+        payload = json.dumps(body).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *args, **kwargs):  # pragma: no cover - silence server logs
+        return
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(name="mock_server")
+def _mock_server():
+    port = _free_port()
+    server = HTTPServer(("127.0.0.1", port), _MockHandler)
+
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{port}/chat"
+    server.shutdown()
+    thread.join(timeout=1)
+
+
+def _write_provider(temp_dir: Path, url: str, token_env: str) -> Path:
+    spec = f"""
+provider: test
+models:
+  - id: test-model
+auth:
+  type: bearer
+  token_env: {token_env}
+endpoints:
+  chat:
+    method: POST
+    url: {url}
+    headers:
+      content-type: application/json
+mappings:
+  request:
+    - from: $.messages
+      to: $.body.messages
+  response:
+    - from: $.data.content
+      to: content
+    - from: $.data.finish_reason
+      to: finish_reason
+constraints:
+  supports:
+    json_mode: true
+    tools: true
+""".strip()
+    provider_path = temp_dir / "provider.yaml"
+    provider_path.write_text(spec, encoding="utf-8")
+    return provider_path
+
+
+@pytest.mark.parametrize("temperature", [None, 0.3])
+def test_python_client_and_openai_wrapper(mock_server: str, temperature: float | None):
+    token_env = "SPECADO_PY_TEST_TOKEN"
+    os.environ[token_env] = "py-secret"
+    try:
+        with TemporaryDirectory() as tmp:
+            temp_path = Path(tmp)
+            provider_path = _write_provider(temp_path, mock_server, token_env)
+
+            prompt = PromptSpec(messages=[Message(role="user", content="Hello!")])
+            client = Client(str(provider_path))
+            response = client.complete(prompt)
+            assert response["content"] == "hello from python"
+
+            openai = OpenAI(str(provider_path))
+            messages = [
+                {"role": "user", "content": "Hello!"},
+            ]
+            completion = openai.chat.completions.create(
+                model="test-model",
+                messages=messages,
+                temperature=temperature,
+            )
+            assert completion.choices[0].message.content == "hello from python"
+    finally:
+        os.environ.pop(token_env, None)


### PR DESCRIPTION
## Summary
- add `pyproject.toml` and top-level Python package exposing dataclass-based client helpers (#44)
- provide `specado.compat.OpenAI` shim with chat.completions.create for basic OpenAI parity
- add pytest suite spinning up a local HTTP server to validate both `Client` and wrapper flows

## Testing
- maturin develop
- pytest python/tests
- cargo test --workspace