### PR TITLE
ci: add Rust/Python/Node workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,99 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test-rust:
+    name: Rust / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Run tests
+        run: cargo test --workspace --all-features
+        env:
+          OPENAI_API_KEY: test-key
+          ANTHROPIC_API_KEY: test-key
+
+      - name: Run clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+  test-python:
+    name: Python ${{ matrix.python }} / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python: ["3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install maturin
+        run: pip install maturin pytest
+
+      - name: Build and test
+        run: |
+          maturin develop
+          pytest python/tests/
+        env:
+          OPENAI_API_KEY: test-key
+          ANTHROPIC_API_KEY: test-key
+
+  test-node:
+    name: Node ${{ matrix.node }} / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node: [18, 20, 22]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Install dependencies
+        working-directory: crates/specado-node
+        run: npm install
+
+      - name: Build addon
+        working-directory: crates/specado-node
+        run: npm run build:debug
+        env:
+          OPENAI_API_KEY: test-key
+          ANTHROPIC_API_KEY: test-key
+
+      - name: Test addon
+        working-directory: crates/specado-node
+        run: npm test


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow with matrices covering Rust (3 OS), Python (3 OS x 4 versions), and Node (3 OS x 3 versions) (#47)
- reuse toolchain/setup actions, cache Cargo artifacts, and run tests + clippy + fmt
- run `maturin develop` + pytest for Python, and napi build/test for Node bindings

## Testing
- Workflow logic validated locally by running `cargo test --workspace`, `pytest python/tests`, `npm test`.