### PR TITLE
feat: adopt neutral provider contract

### DIFF
--- a/crates/specado-core/src/audit.rs
+++ b/crates/specado-core/src/audit.rs
@@ -292,7 +292,7 @@ const DEFAULT_REDACTION: &[&str] = &[
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::ProviderApi;
+    use crate::types::Capabilities;
     use serde_json::json;
     use std::collections::HashMap;
 
@@ -324,7 +324,8 @@ mod tests {
         ctx.note_provider(&ProviderSpec {
             provider: "demo".into(),
             models: vec![crate::types::ModelConfig { id: "m".into() }],
-            api: ProviderApi::ChatCompletions,
+            interface: Some("conversational.generate".into()),
+            contract_version: Some("1.0.0".into()),
             inherits: None,
             endpoints: crate::types::Endpoints {
                 chat: crate::types::EndpointConfig {
@@ -346,7 +347,9 @@ mod tests {
             auth: crate::auth::AuthScheme::Custom {
                 headers: HashMap::new(),
             },
-            capabilities: HashMap::new(),
+            capabilities: Capabilities::default(),
+            capabilities_extra: HashMap::new(),
+            extensions: HashMap::new(),
             unsupported_parameters: Vec::new(),
         });
 

--- a/crates/specado-core/src/hot_reload.rs
+++ b/crates/specado-core/src/hot_reload.rs
@@ -246,7 +246,6 @@ pub fn start_hot_reload(_config: HotReloadConfig, _cache: ProviderCache) -> HotR
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
     use tempfile::{tempdir, NamedTempFile};
 
     #[test]
@@ -395,8 +394,8 @@ unsupported_parameters:
         assert_eq!(spec.provider, "demo");
         assert_eq!(spec.models[0].id, "child");
         assert_eq!(spec.endpoints.chat.url, "https://api.example.com");
-        assert_eq!(spec.capabilities.get("supports_tools"), Some(&json!(true)));
-        assert_eq!(spec.capabilities.get("context_window"), Some(&json!(2000)));
+        assert!(spec.capabilities.supports_tools);
+        assert_eq!(spec.capabilities.context_window, Some(2000));
         assert_eq!(spec.unsupported_parameters, vec!["$.sampling.temperature"]);
     }
 }

--- a/crates/specado-core/src/transformer/detect/drop.rs
+++ b/crates/specado-core/src/transformer/detect/drop.rs
@@ -28,10 +28,9 @@ pub fn detect_drops(prompt: &PromptSpec, provider: &ProviderSpec, report: &mut L
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::ProviderApi;
     use crate::types::{
-        Constraints, EndpointConfig, Endpoints, HttpMethod, Mappings, ModelConfig, RequestMapping,
-        ResponseConfig, ResponseMapping, SamplingConfig, StrictMode, SupportFlags,
+        Capabilities, Constraints, EndpointConfig, Endpoints, HttpMethod, Mappings, ModelConfig,
+        RequestMapping, ResponseConfig, ResponseMapping, SamplingConfig, StrictMode, SupportFlags,
     };
     use std::collections::HashMap;
 
@@ -49,7 +48,8 @@ mod tests {
         ProviderSpec {
             provider: "demo".into(),
             models: vec![ModelConfig { id: "demo".into() }],
-            api: ProviderApi::ChatCompletions,
+            interface: Some("conversational.generate".into()),
+            contract_version: Some("1.0.0".into()),
             inherits: None,
             endpoints: Endpoints {
                 chat: EndpointConfig {
@@ -74,7 +74,9 @@ mod tests {
             auth: crate::auth::AuthScheme::Bearer {
                 token_env: "TOKEN".into(),
             },
-            capabilities: HashMap::new(),
+            capabilities: Capabilities::default(),
+            capabilities_extra: HashMap::new(),
+            extensions: HashMap::new(),
             unsupported_parameters: Vec::new(),
         }
     }

--- a/crates/specado-core/src/transformer/detect/relocate.rs
+++ b/crates/specado-core/src/transformer/detect/relocate.rs
@@ -37,10 +37,9 @@ pub fn detect_relocate(prompt: &PromptSpec, provider: &ProviderSpec, report: &mu
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::ProviderApi;
     use crate::types::{
-        Constraints, EndpointConfig, Endpoints, HttpMethod, Mappings, Message, ModelConfig,
-        RequestMapping, ResponseMapping, StrictMode, SupportFlags,
+        Capabilities, Constraints, EndpointConfig, Endpoints, HttpMethod, Mappings, Message,
+        ModelConfig, RequestMapping, ResponseMapping, StrictMode, SupportFlags,
     };
     use std::collections::HashMap;
 
@@ -50,7 +49,8 @@ mod tests {
             models: vec![ModelConfig {
                 id: "gpt-4o".into(),
             }],
-            api: ProviderApi::ChatCompletions,
+            interface: Some("conversational.generate".into()),
+            contract_version: Some("1.0.0".into()),
             inherits: None,
             endpoints: Endpoints {
                 chat: EndpointConfig {
@@ -80,7 +80,9 @@ mod tests {
             auth: crate::auth::AuthScheme::Bearer {
                 token_env: "DUMMY".into(),
             },
-            capabilities: HashMap::new(),
+            capabilities: Capabilities::default(),
+            capabilities_extra: HashMap::new(),
+            extensions: HashMap::new(),
             unsupported_parameters: Vec::new(),
         }
     }

--- a/crates/specado-core/src/transformer/detect/unsupported.rs
+++ b/crates/specado-core/src/transformer/detect/unsupported.rs
@@ -44,10 +44,9 @@ pub fn detect_unsupported(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::ProviderApi;
     use crate::types::{
-        Constraints, EndpointConfig, Endpoints, HttpMethod, Mappings, ModelConfig, RequestMapping,
-        ResponseConfig, ResponseMapping, StrictMode, SupportFlags, Tool,
+        Capabilities, Constraints, EndpointConfig, Endpoints, HttpMethod, Mappings, ModelConfig,
+        RequestMapping, ResponseConfig, ResponseMapping, StrictMode, SupportFlags, Tool,
     };
     use std::collections::HashMap;
 
@@ -55,7 +54,8 @@ mod tests {
         ProviderSpec {
             provider: "fake".into(),
             models: vec![ModelConfig { id: "m".into() }],
-            api: ProviderApi::ChatCompletions,
+            interface: Some("conversational.generate".into()),
+            contract_version: Some("1.0.0".into()),
             inherits: None,
             endpoints: Endpoints {
                 chat: EndpointConfig {
@@ -82,7 +82,9 @@ mod tests {
             auth: crate::auth::AuthScheme::Bearer {
                 token_env: "TOKEN".into(),
             },
-            capabilities: HashMap::new(),
+            capabilities: Capabilities::default(),
+            capabilities_extra: HashMap::new(),
+            extensions: HashMap::new(),
             unsupported_parameters: Vec::new(),
         }
     }

--- a/crates/specado-core/src/transformer/normalize.rs
+++ b/crates/specado-core/src/transformer/normalize.rs
@@ -2,7 +2,7 @@ use crate::error::{Error, Result};
 use crate::types::{
     Extensions, FinishReason, LossinessReport, ProviderSpec, StrictMode, UniformResponse,
 };
-use serde_json::{Map as JsonMap, Value};
+use serde_json::Value;
 use serde_json_path::JsonPath;
 
 pub fn normalize(raw: Value, provider: &ProviderSpec) -> Result<UniformResponse> {
@@ -38,17 +38,7 @@ pub fn normalize(raw: Value, provider: &ProviderSpec) -> Result<UniformResponse>
         }
     }
 
-    let provider_capabilities = if provider.capabilities.is_empty() {
-        None
-    } else {
-        Some(Value::Object(
-            provider
-                .capabilities
-                .iter()
-                .map(|(k, v)| (k.clone(), v.clone()))
-                .collect::<JsonMap<_, _>>(),
-        ))
-    };
+    let provider_capabilities = provider.capabilities_json();
 
     Ok(UniformResponse {
         content,
@@ -81,10 +71,9 @@ fn map_finish_reason(raw: &str) -> FinishReason {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::ProviderApi;
     use crate::types::{
-        Constraints, EndpointConfig, Endpoints, HttpMethod, Mappings, ModelConfig, ProviderSpec,
-        ResponseMapping, SupportFlags,
+        Capabilities, Constraints, EndpointConfig, Endpoints, HttpMethod, Mappings, ModelConfig,
+        ProviderSpec, ResponseMapping, SupportFlags,
     };
     use serde_json::json;
     use std::collections::HashMap;
@@ -95,7 +84,8 @@ mod tests {
             models: vec![ModelConfig {
                 id: "gpt-4o".into(),
             }],
-            api: ProviderApi::ChatCompletions,
+            interface: Some("conversational.generate".into()),
+            contract_version: Some("1.0.0".into()),
             inherits: None,
             endpoints: Endpoints {
                 chat: EndpointConfig {
@@ -126,7 +116,9 @@ mod tests {
             auth: crate::auth::AuthScheme::Bearer {
                 token_env: "KEY".into(),
             },
-            capabilities: HashMap::new(),
+            capabilities: Capabilities::default(),
+            capabilities_extra: HashMap::new(),
+            extensions: HashMap::new(),
             unsupported_parameters: Vec::new(),
         }
     }

--- a/crates/specado-core/src/transformer/translate.rs
+++ b/crates/specado-core/src/transformer/translate.rs
@@ -10,7 +10,7 @@ use serde_json_path::JsonPath;
 pub fn translate(prompt: &PromptSpec, provider: &ProviderSpec) -> Result<(Value, LossinessReport)> {
     let (base_payload, report) = translate_with_mappings(prompt, provider)?;
 
-    let payload = match provider.api {
+    let payload = match provider.api_kind() {
         ProviderApi::ChatCompletions => base_payload,
         ProviderApi::OpenaiResponses => reshape_openai_responses(prompt, provider, base_payload)?,
         ProviderApi::AnthropicMessagesClaude4 => {
@@ -470,9 +470,9 @@ enum PathSegment {
 mod tests {
     use super::*;
     use crate::types::{
-        Constraints, EndpointConfig, Endpoints, HttpMethod, JsonSchema, Mappings, Message,
-        MessageRole, ModelConfig, PromptSpec, RequestMapping, ResponseConfig, ResponseMapping,
-        SamplingConfig, StrictMode, SupportFlags, Tool,
+        Capabilities, Constraints, EndpointConfig, Endpoints, HttpMethod, JsonSchema, Mappings,
+        Message, MessageRole, ModelConfig, PromptSpec, RequestMapping, ResponseConfig,
+        ResponseMapping, SamplingConfig, StrictMode, SupportFlags, Tool,
     };
     use std::collections::HashMap;
 
@@ -482,7 +482,8 @@ mod tests {
             models: vec![ModelConfig {
                 id: "gpt-4o".into(),
             }],
-            api: ProviderApi::ChatCompletions,
+            interface: Some("conversational.generate".into()),
+            contract_version: Some("1.0.0".into()),
             inherits: None,
             endpoints: Endpoints {
                 chat: EndpointConfig {
@@ -507,7 +508,9 @@ mod tests {
             auth: crate::auth::AuthScheme::Bearer {
                 token_env: "OPENAI_KEY".into(),
             },
-            capabilities: HashMap::new(),
+            capabilities: Capabilities::default(),
+            capabilities_extra: HashMap::new(),
+            extensions: HashMap::new(),
             unsupported_parameters: Vec::new(),
         }
     }

--- a/crates/specado-core/src/types/mod.rs
+++ b/crates/specado-core/src/types/mod.rs
@@ -9,7 +9,7 @@ pub use prompt::{
     StrictMode, Tool, ToolChoice, ToolChoiceString,
 };
 pub use provider::{
-    Constraints, EndpointConfig, Endpoints, HttpMethod, Mappings, ModelConfig, ProviderApi,
-    ProviderSpec, RequestMapping, ResponseMapping, SupportFlags,
+    Capabilities, Constraints, EndpointConfig, Endpoints, HttpMethod, Mappings, ModelConfig,
+    ProviderApi, ProviderSpec, RequestMapping, ResponseMapping, SupportFlags,
 };
 pub use response::{Extensions, FinishReason, UniformResponse, Usage};

--- a/crates/specado-core/src/types/provider.rs
+++ b/crates/specado-core/src/types/provider.rs
@@ -1,12 +1,10 @@
 use crate::auth::AuthScheme;
 use serde::{Deserialize, Serialize};
-use serde_json::Value as JsonValue;
+use serde_json::{Map as JsonMap, Value as JsonValue};
 use std::collections::HashMap;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProviderApi {
-    #[default]
     ChatCompletions,
     OpenaiResponses,
     AnthropicMessagesClaude4,
@@ -16,8 +14,10 @@ pub enum ProviderApi {
 pub struct ProviderSpec {
     pub provider: String,
     pub models: Vec<ModelConfig>,
-    #[serde(default)]
-    pub api: ProviderApi,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub interface: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub contract_version: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub inherits: Option<String>,
     pub endpoints: Endpoints,
@@ -25,7 +25,11 @@ pub struct ProviderSpec {
     pub constraints: Constraints,
     pub auth: AuthScheme,
     #[serde(default)]
-    pub capabilities: HashMap<String, JsonValue>,
+    pub capabilities: Capabilities,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub capabilities_extra: HashMap<String, JsonValue>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub extensions: HashMap<String, JsonValue>,
     #[serde(default)]
     pub unsupported_parameters: Vec<String>,
 }
@@ -85,6 +89,123 @@ pub struct Constraints {
 pub struct SupportFlags {
     pub json_mode: bool,
     pub tools: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct Capabilities {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_window: Option<u64>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub supports_tools: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub supports_custom_tools: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub supports_parallel_tool_calls: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub supports_allowed_tools: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub supports_json_mode: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub supports_seed: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub supports_frequency_penalty: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub supports_presence_penalty: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub supports_logit_bias: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub supports_logprobs: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub supports_top_logprobs: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub supports_n: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub supports_response_format: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub supports_stop: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub supports_temperature: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub supports_top_p: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub supports_top_k: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub supports_image_input: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub supports_extended_thinking: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub responses_api: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub reasoning_controls: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thought_signatures: Option<String>,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+impl ProviderSpec {
+    pub fn interface_hint(&self) -> Option<&str> {
+        self.interface.as_deref()
+    }
+
+    pub fn contract_version(&self) -> Option<&str> {
+        self.contract_version.as_deref()
+    }
+
+    pub fn api_kind(&self) -> ProviderApi {
+        if let Some(interface) = self.interface_hint() {
+            if interface.starts_with("x_") {
+                return self.infer_api_from_context();
+            }
+
+            match interface {
+                "conversational.generate"
+                | "conversational.stream"
+                | "text.generate"
+                | "text.extract"
+                | "tools.call" => {
+                    return self.infer_api_from_context();
+                }
+                _ => {}
+            }
+        }
+
+        self.infer_api_from_context()
+    }
+
+    fn infer_api_from_context(&self) -> ProviderApi {
+        let url = self.endpoints.chat.url.to_ascii_lowercase();
+
+        if url.contains("/responses") {
+            ProviderApi::OpenaiResponses
+        } else if url.contains("/messages") {
+            ProviderApi::AnthropicMessagesClaude4
+        } else if self.provider.eq_ignore_ascii_case("anthropic") {
+            ProviderApi::AnthropicMessagesClaude4
+        } else {
+            ProviderApi::ChatCompletions
+        }
+    }
+
+    pub fn capabilities_json(&self) -> Option<JsonValue> {
+        let mut map = JsonMap::new();
+
+        if let Ok(JsonValue::Object(obj)) = serde_json::to_value(&self.capabilities) {
+            map.extend(obj);
+        }
+
+        for (key, value) in &self.capabilities_extra {
+            map.insert(key.clone(), value.clone());
+        }
+
+        if map.is_empty() {
+            None
+        } else {
+            Some(JsonValue::Object(map))
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/specado-providers/providers/anthropic/_base.yaml
+++ b/crates/specado-providers/providers/anthropic/_base.yaml
@@ -1,5 +1,6 @@
 provider: anthropic
-api: anthropic_messages_claude4
+interface: conversational.generate
+contract_version: "1.0.0"
 
 auth:
   type: apikey

--- a/crates/specado-providers/providers/openai/_base-chat-completions.yaml
+++ b/crates/specado-providers/providers/openai/_base-chat-completions.yaml
@@ -1,5 +1,6 @@
 provider: openai
-api: chat_completions
+interface: conversational.generate
+contract_version: "1.0.0"
 
 auth:
   type: bearer

--- a/crates/specado-providers/providers/openai/_base-responses.yaml
+++ b/crates/specado-providers/providers/openai/_base-responses.yaml
@@ -1,5 +1,6 @@
 provider: openai
-api: openai_responses
+interface: conversational.generate
+contract_version: "1.0.0"
 
 auth:
   type: bearer

--- a/crates/specado-schemas/schemas/provider-spec.v1.schema.json
+++ b/crates/specado-schemas/schemas/provider-spec.v1.schema.json
@@ -16,22 +16,81 @@
       }
     },
     "inherits": {"type": "string"},
-    "api": {
+    "interface": {
       "type": "string",
-      "enum": [
-        "chat_completions",
-        "openai_responses",
-        "anthropic_messages_claude4",
-        "embeddings",
-        "images",
-        "speech",
-        "video"
-      ],
-      "default": "chat_completions"
+      "description": "Neutral interface hint (e.g., conversational.generate)",
+      "anyOf": [
+        {
+          "enum": [
+            "conversational.generate",
+            "conversational.stream",
+            "text.generate",
+            "text.extract",
+            "text.moderate",
+            "tools.call",
+            "embeddings.generate",
+            "search.rerank",
+            "vision.describe",
+            "image.generate",
+            "image.edit",
+            "image.variations",
+            "speech.synthesize",
+            "audio.transcribe",
+            "audio.translate",
+            "video.generate",
+            "video.transcribe"
+          ]
+        },
+        {
+          "pattern": "^x[_\\-A-Za-z0-9.]+$"
+        }
+      ]
+    },
+    "contract_version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
     },
     "capabilities": {
       "type": "object",
-      "additionalProperties": true
+      "properties": {
+        "context_window": {"type": "integer", "minimum": 1},
+        "supports_tools": {"type": "boolean", "default": false},
+        "supports_custom_tools": {"type": "boolean", "default": false},
+        "supports_parallel_tool_calls": {"type": "boolean", "default": false},
+        "supports_allowed_tools": {"type": "boolean", "default": false},
+        "supports_json_mode": {"type": "boolean", "default": false},
+        "supports_seed": {"type": "boolean", "default": false},
+        "supports_frequency_penalty": {"type": "boolean", "default": false},
+        "supports_presence_penalty": {"type": "boolean", "default": false},
+        "supports_logit_bias": {"type": "boolean", "default": false},
+        "supports_logprobs": {"type": "boolean", "default": false},
+        "supports_top_logprobs": {"type": "boolean", "default": false},
+        "supports_n": {"type": "boolean", "default": false},
+        "supports_response_format": {"type": "boolean", "default": false},
+        "supports_stop": {"type": "boolean", "default": false},
+        "supports_temperature": {"type": "boolean", "default": false},
+        "supports_top_p": {"type": "boolean", "default": false},
+        "supports_top_k": {"type": "boolean", "default": false},
+        "supports_image_input": {"type": "boolean", "default": false},
+        "supports_extended_thinking": {"type": "boolean", "default": false},
+        "responses_api": {"type": "boolean", "default": false},
+        "reasoning_controls": {"type": "array", "items": {"type": "string"}},
+        "thought_signatures": {"type": "string"}
+      },
+      "additionalProperties": false,
+      "default": {}
+    },
+    "extensions": {
+      "type": "object",
+      "propertyNames": {"pattern": "^x[_\\-A-Za-z0-9.]+$"},
+      "additionalProperties": true,
+      "default": {}
+    },
+    "capabilities_extra": {
+      "type": "object",
+      "propertyNames": {"pattern": "^x[_\\-A-Za-z0-9.]+$"},
+      "additionalProperties": true,
+      "default": {}
     },
     "unsupported_parameters": {
       "type": "array",

--- a/docs/process/PROVIDER_INHERITANCE.md
+++ b/docs/process/PROVIDER_INHERITANCE.md
@@ -36,7 +36,8 @@ anthropic/
 Each spec YAML follows the schema defined in `crates/specado-schemas`:
 
 - `inherits` points to another spec file (relative path) that will be merged first.
-- `capabilities` stores provider-specific metadata (context window, tool support, etc.).
+- `capabilities` stores provider-specific metadata with typed fields (context window, feature flags, reasoning controls).
+- `capabilities_extra` allows experimental `x_*` capability keys without schema churn.
 - `unsupported_parameters` lists PromptSpec paths that should trigger lossiness warnings.
 - `mappings` describe declarative JSONPath translations for request and response payloads.
 


### PR DESCRIPTION
## Summary
- add neutral  hint and  to provider schema/types
- replace free-form capabilities with structured fields plus escape hatch
- migrate provider YAMLs to the new contract and defaults

## Testing
- [x] cargo fmt
- [x] cargo test --workspace

## Related Issues
Closes #87
Closes #88
Closes #89
