### PR TITLE
fix: satisfy clippy in provider api inference

### DIFF
--- a/crates/specado-core/src/types/provider.rs
+++ b/crates/specado-core/src/types/provider.rs
@@ -180,9 +180,7 @@ impl ProviderSpec {
 
         if url.contains("/responses") {
             ProviderApi::OpenaiResponses
-        } else if url.contains("/messages") {
-            ProviderApi::AnthropicMessagesClaude4
-        } else if self.provider.eq_ignore_ascii_case("anthropic") {
+        } else if url.contains("/messages") || self.provider.eq_ignore_ascii_case("anthropic") {
             ProviderApi::AnthropicMessagesClaude4
         } else {
             ProviderApi::ChatCompletions


### PR DESCRIPTION
## Summary
- collapse redundant branch in 
- keep Anthropic detection working by checking URL or provider name

## Testing
- [x] cargo fmt
- [x] cargo test --workspace
