### PR TITLE
docs: document interface taxonomy and overlays

### DIFF
--- a/crates/specado-core/src/adapter/mod.rs
+++ b/crates/specado-core/src/adapter/mod.rs
@@ -76,7 +76,6 @@ impl AdapterRegistry {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/specado-core/src/hot_reload.rs
+++ b/crates/specado-core/src/hot_reload.rs
@@ -1,5 +1,5 @@
-use crate::error::{Error, Result};
 use crate::adapter::AdapterRegistry;
+use crate::error::{Error, Result};
 use crate::types::ProviderSpec;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
@@ -85,16 +85,27 @@ fn merge_values(base: &mut JsonValue, overlay: &JsonValue) {
     *base = overlay.clone();
 }
 
-fn load_overlays() -> Result<Vec<OverlaySpec>> {
-    let overlays_dir = Path::new("overlays");
-    if !overlays_dir.exists() {
-        return Ok(Vec::new());
-    }
+fn load_overlays(spec_path: &Path) -> Result<Vec<OverlaySpec>> {
+    let overlays_dir = spec_path
+        .ancestors()
+        .find_map(|ancestor| {
+            let candidate = ancestor.join("overlays");
+            if candidate.is_dir() {
+                Some(candidate)
+            } else {
+                None
+            }
+        });
+
+    let overlays_dir = match overlays_dir {
+        Some(dir) => dir,
+        None => return Ok(Vec::new()),
+    };
 
     let mut overlays = Vec::new();
-    for entry in fs::read_dir(overlays_dir).map_err(|e| {
-        Error::Config(format!("Failed to read overlays directory: {}", e))
-    })? {
+    for entry in fs::read_dir(overlays_dir)
+        .map_err(|e| Error::Config(format!("Failed to read overlays directory: {}", e)))?
+    {
         let path = entry
             .map_err(|e| Error::Config(format!("Failed to read overlay entry: {}", e)))?
             .path();
@@ -121,8 +132,6 @@ fn load_overlays() -> Result<Vec<OverlaySpec>> {
 }
 
 fn merge_overlays(value: JsonValue, overlays: Vec<OverlaySpec>) -> Result<JsonValue> {
-    let mut value = value;
-
     if overlays.is_empty() {
         return Ok(value);
     }
@@ -134,11 +143,12 @@ fn merge_overlays(value: JsonValue, overlays: Vec<OverlaySpec>) -> Result<JsonVa
         ))
     })?;
 
+    let mut combined = value;
+
     let adapter = AdapterRegistry::select(&provider);
     let adapter_key = adapter.kind().registry_key();
     let provider_contract = provider.contract_version().unwrap_or("1.0.0");
 
-    let mut combined = value;
     for overlay in overlays {
         if !overlay
             .target
@@ -148,11 +158,7 @@ fn merge_overlays(value: JsonValue, overlays: Vec<OverlaySpec>) -> Result<JsonVa
             continue;
         }
 
-        if !overlay
-            .target
-            .adapter
-            .eq_ignore_ascii_case(adapter_key)
-        {
+        if !overlay.target.adapter.eq_ignore_ascii_case(adapter_key) {
             continue;
         }
 
@@ -165,10 +171,7 @@ fn merge_overlays(value: JsonValue, overlays: Vec<OverlaySpec>) -> Result<JsonVa
             )));
         }
 
-        merge_values(
-            &mut combined,
-            &JsonValue::Object(overlay.data.clone()),
-        );
+        merge_values(&mut combined, &JsonValue::Object(overlay.data.clone()));
     }
 
     Ok(combined)
@@ -280,8 +283,8 @@ impl ProviderCache {
 
         let mut visited = HashSet::new();
         let merged_value = load_spec_value(&canonical, &mut visited)?;
-    let overlays = load_overlays()?;
-        let merged_value = merge_overlays(merged_value, overlays)?;
+        let overlays = load_overlays(&canonical)?;
+    let merged_value = merge_overlays(merged_value, overlays)?;
         let mut spec: ProviderSpec = serde_json::from_value(merged_value)
             .map_err(|e| Error::Config(format!("Failed to parse provider spec: {}", e)))?;
         spec.inherits = None;
@@ -516,12 +519,29 @@ unsupported_parameters:
     fn load_or_read_applies_overlays() {
         let dir = tempdir().expect("temp dir");
         let spec_path = dir.path().join("openai.yaml");
+        let overlays_dir = dir.path().join("overlays");
+        fs::create_dir(&overlays_dir).expect("overlay dir");
+        fs::write(
+            overlays_dir.join("openai.responses.yaml"),
+            r#"overlay_for:
+  provider: openai
+  adapter: openai_responses
+  contract_version: "1.0.0"
+
+extensions:
+  x-specado:
+    request_defaults:
+      max_output_tokens: 1024
+"#,
+        )
+        .expect("overlay file");
+
         fs::write(
             &spec_path,
             r#"provider: openai
 models:
   - id: test
-interface: conversational.generate
+interface: text.generate
 contract_version: "1.0.0"
 endpoints:
   chat:
@@ -543,9 +563,7 @@ auth:
         .expect("write spec");
 
         let cache = ProviderCache::new();
-        let spec = cache
-            .load_or_read(&spec_path)
-            .expect("spec with overlays");
+        let spec = cache.load_or_read(&spec_path).expect("spec with overlays");
 
         assert_eq!(spec.provider, "openai");
         let defaults = spec

--- a/crates/specado-providers/providers/openai/_base-responses.yaml
+++ b/crates/specado-providers/providers/openai/_base-responses.yaml
@@ -1,5 +1,5 @@
 provider: openai
-interface: conversational.generate
+interface: text.generate
 contract_version: "1.0.0"
 
 auth:

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -40,12 +40,18 @@ OPENAI_API_KEY=sk-your-key \
   --prompt examples/prompts/basic_chat.json \
   --provider crates/specado-providers/providers/openai/gpt-5/base.yaml \
   --audit-target stdout
+
+# generate embeddings using the neutral interface
+OPENAI_API_KEY=sk-your-key \
+./target/debug/specado run \
+  --prompt examples/prompts/embeddings_query.json \
+  --provider crates/specado-providers/providers/openai/gpt-5/base.yaml
 ```
 
 The helper script `examples/cli_preview.sh` wraps the preview command and documents the expected environment when you need a quick smoke test.
 
-> **Model metadata**
-> The sample prompt `examples/prompts/basic_chat.json` includes metadata that targets OpenAI's GPT-5 Responses API (`openai_model`, reasoning effort, verbosity, max output tokens) and Anthropic's Claude Sonnet 4.5 (`anthropic_model`, thinking configuration, and max tokens). Tweak these fields to match the models and limits available to your account. See `docs/process/PROVIDER_INHERITANCE.md` for a full field reference.
+> **Model metadata & overlays**
+> The sample prompt `examples/prompts/basic_chat.json` includes metadata that targets OpenAI's GPT-5 Responses API (`openai_model`, reasoning effort, verbosity, max output tokens) and Anthropic's Claude Sonnet 4.5 (`anthropic_model`, thinking configuration, and max tokens). Tweak these fields to match the models and limits available to your account. The provider specs declare neutral interfaces (see `docs/process/INTERFACE_TAXONOMY.md`), while per-adapter defaults live in `overlays/`. See `docs/process/PROVIDER_INHERITANCE.md` for the full field reference.
 
 ## 3. Python quickstart
 The Python bindings are published from `crates/specado-py` and surfaced to the Python package in `python/specado`. Use `maturin` to build the native extension in-place, then run the sample program in `examples/python_basic.py`.

--- a/docs/process/INTERFACE_TAXONOMY.md
+++ b/docs/process/INTERFACE_TAXONOMY.md
@@ -1,0 +1,69 @@
+# Interface Taxonomy
+
+Specado uses neutral interface hints to route provider specs without hardcoding vendor names. Each hint follows the pattern `domain.action[.mode]`.
+
+## Conversational / Text
+
+| Hint | Description |
+| --- | --- |
+| `conversational.generate` | Multi-turn chat (tool use allowed) |
+| `conversational.stream` | Streaming chat responses |
+| `text.generate` | Single-turn completion |
+| `text.extract` | Structured/JSON output |
+| `text.moderate` | Safety/policy classification |
+
+## Tooling
+
+| Hint | Description |
+| --- | --- |
+| `tools.call` | Function/tool orchestration |
+
+## Embeddings / Search
+
+| Hint | Description |
+| --- | --- |
+| `embeddings.generate` | Generate vector embeddings |
+| `search.rerank` | Rank documents for a query |
+
+## Vision / Images / Video
+
+| Hint | Description |
+| --- | --- |
+| `vision.describe` | Caption/OCR multimodal input |
+| `image.generate` | Create images |
+| `image.edit` | Edit an existing image |
+| `image.variations` | Produce variations of an image |
+| `video.generate` | Generate video content |
+| `video.transcribe` | Transcribe video |
+
+## Audio / Speech
+
+| Hint | Description |
+| --- | --- |
+| `speech.synthesize` | Text to speech |
+| `audio.transcribe` | Speech to text |
+| `audio.translate` | Speech translation |
+
+## Files & Batch (reserved)
+
+| Hint | Description |
+| --- | --- |
+| `files.upload` | Upload provider files |
+| `files.retrieve` | Retrieve provider files |
+| `batch.submit` | Submit batch job |
+| `batch.status` | Query batch job |
+
+Providers may also use experimental hints starting with `x_`.
+
+## Adapter Precedence
+
+The adapter registry evaluates hints in this order:
+
+1. Direct `interface` match.
+2. Endpoint URL domain/path.
+3. Provider name heuristics.
+4. Default to chat completions.
+
+## Overlays
+
+Overlays live in `overlays/<provider>.<adapter>.yaml` and declare `overlay_for` metadata. Each overlay is applied after inheritance using precedence `spec < overlay < runtime overrides`.

--- a/docs/process/PROVIDER_INHERITANCE.md
+++ b/docs/process/PROVIDER_INHERITANCE.md
@@ -39,14 +39,31 @@ Each spec YAML follows the schema defined in `crates/specado-schemas`:
 - `capabilities` stores provider-specific metadata with typed fields (context window, feature flags, reasoning controls).
 - `capabilities_extra` allows experimental `x_*` capability keys without schema churn.
 - `extensions` is reserved for experimental `x_*` fields that are not part of the stable contract.
+- Overlays supplement the spec with provider defaults (see [Interface Taxonomy](INTERFACE_TAXONOMY.md)).
 - `unsupported_parameters` lists PromptSpec paths that should trigger lossiness warnings.
 - `mappings` describe declarative JSONPath translations for request and response payloads.
+- `interface` provides a neutral routing hint (for example, `conversational.generate`).
+- `contract_version` records the semver contract (`1.0.0`, etc.) so overlays and adapters can validate compatibility.
 
 Overlays placed under `overlays/<provider>.<adapter>.yaml` can layer provider-specific defaults. Each overlay file declares `overlay_for` metadata (`provider`, `adapter`, `contract_version`) so the runtime can validate when it applies the overlay.
 
 ## Overlays
 
 Overlays let you keep provider-specific defaults or quirks outside the base spec. When the adapter registry selects an adapter, it merges any matching overlays (by provider, adapter key, and contract version) on top of the spec using the precedence `spec < overlay < runtime overrides`. Overlay files live in the repo-level `overlays/` directory and use the naming convention `<provider>.<adapter>.yaml` (for example, `openai.responses.yaml`).
+
+Example overlay (`overlays/openai.responses.yaml`):
+
+```
+overlay_for:
+  provider: openai
+  adapter: openai_responses
+  contract_version: "1.0.0"
+
+extensions:
+  x-specado:
+    request_defaults:
+      max_output_tokens: 1024
+```
 
 When loading a spec, the engine merges the inheritance chain, reporting an error if cycles are detected.
 

--- a/examples/prompts/embeddings_query.json
+++ b/examples/prompts/embeddings_query.json
@@ -1,0 +1,13 @@
+{
+  "version": "1",
+  "metadata": {
+    "openai_model": "text-embedding-3-small"
+  },
+  "input": {
+    "documents": [
+      "Specado keeps provider specs portable.",
+      "Declarative adapters map prompts between APIs."
+    ],
+    "query": "portable prompt adapters"
+  }
+}


### PR DESCRIPTION
## Summary
- add  describing neutral interface hints
- update provider specs/docs/quickstart to reference interfaces and overlays
- add embeddings prompt example and tighten overlay lookup in tests

## Testing
- [x] cargo fmt
- [x] cargo test --workspace

## Related Issues
Closes #91
