### PR TITLE
feat(cli): add provider/model flags to ask

### DIFF
--- a/crates/specado-cli/src/main.rs
+++ b/crates/specado-cli/src/main.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 
 #[cfg(feature = "audit-logging")]
 use specado_core::audit::{AuditConfig, AuditContext, AuditTarget};
+use specado_core::hot_reload::ProviderCache;
 #[cfg(feature = "hot-reload")]
 use specado_core::hot_reload::{set_global_config, HotReloadConfig};
 
@@ -30,6 +31,12 @@ enum Commands {
     Ask {
         /// The user prompt to send to the model
         prompt: String,
+        /// Provider name or path to the provider spec
+        #[arg(long)]
+        provider: Option<String>,
+        /// Model identifier for the chosen provider
+        #[arg(long)]
+        model: Option<String>,
         #[command(flatten)]
         runtime: RuntimeOptions,
     },
@@ -63,7 +70,12 @@ async fn main() {
     let cli = Cli::parse();
 
     let result = match cli.command {
-        Commands::Ask { prompt, runtime } => ask_command(prompt, runtime).await,
+        Commands::Ask {
+            prompt,
+            provider,
+            model,
+            runtime,
+        } => ask_command(prompt, provider, model, runtime).await,
         Commands::Validate { spec } => validate_command(spec).await,
         Commands::Preview {
             prompt,
@@ -109,8 +121,13 @@ async fn validate_command(spec_path: PathBuf) -> Result<()> {
     Ok(())
 }
 
-async fn ask_command(prompt: String, runtime: RuntimeOptions) -> Result<()> {
-    let provider_path = default_provider_path()?;
+async fn ask_command(
+    prompt: String,
+    provider_flag: Option<String>,
+    model_flag: Option<String>,
+    runtime: RuntimeOptions,
+) -> Result<()> {
+    let provider_path = resolve_provider_path(provider_flag.as_deref(), model_flag.as_deref())?;
 
     #[cfg(feature = "hot-reload")]
     apply_hot_reload_config(&runtime, &provider_path);
@@ -239,6 +256,313 @@ fn default_provider_path() -> Result<PathBuf> {
     Err(anyhow!(
         "Default provider spec not found. Set SPECADO_DEFAULT_PROVIDER to a valid provider YAML."
     ))
+}
+
+fn resolve_provider_path(provider: Option<&str>, model: Option<&str>) -> Result<PathBuf> {
+    if provider.is_none() {
+        if let Some(model_flag) = model {
+            if !model_flag.trim().is_empty() {
+                return Err(anyhow!(
+                    "--model requires --provider. Pass both flags or omit --model."
+                ));
+            }
+        }
+        return default_provider_path();
+    }
+
+    let provider_flag = provider.unwrap().trim();
+    if provider_flag.is_empty() {
+        return Err(anyhow!("--provider cannot be empty"));
+    }
+
+    let cache = ProviderCache::new();
+    let provider_path = PathBuf::from(provider_flag);
+    if provider_path.is_file() {
+        validate_model_for_path(&provider_path, model, &cache)?;
+        return Ok(provider_path);
+    }
+
+    if provider_path.is_dir() {
+        return resolve_provider_from_dir(&provider_path, model, &cache);
+    }
+
+    if let Ok(resolved) = provider_path.canonicalize() {
+        if resolved.is_file() {
+            validate_model_for_path(&resolved, model, &cache)?;
+            return Ok(resolved);
+        }
+    }
+
+    let providers_dir = locate_providers_dir()?;
+    let joined_path = providers_dir.join(provider_flag);
+    if joined_path.is_file() {
+        validate_model_for_path(&joined_path, model, &cache)?;
+        return Ok(joined_path);
+    }
+    if joined_path.is_dir() {
+        return resolve_provider_from_dir(&joined_path, model, &cache);
+    }
+
+    if provider_flag.contains(std::path::MAIN_SEPARATOR)
+        || provider_flag.contains('/')
+        || provider_flag.contains('\\')
+        || provider_flag.ends_with(".yaml")
+        || provider_flag.ends_with(".yml")
+    {
+        return Err(anyhow!(
+            "Provider spec '{}' not found. Pass an existing path or provider name.",
+            provider_flag
+        ));
+    }
+
+    let provider_dir = providers_dir.join(provider_flag);
+    if !provider_dir.is_dir() {
+        let available = list_available_providers(&providers_dir)?;
+        let hint = if available.is_empty() {
+            "No providers found in the catalog. Set SPECADO_PROVIDERS_DIR or pass a provider spec path."
+                .to_string()
+        } else {
+            format!("Known providers: {}", available.join(", "))
+        };
+        return Err(anyhow!("Unknown provider '{}'. {}", provider_flag, hint));
+    }
+
+    resolve_provider_from_dir(&provider_dir, model, &cache)
+}
+
+fn validate_model_for_path(path: &Path, model: Option<&str>, cache: &ProviderCache) -> Result<()> {
+    let Some(model_id) = model.filter(|m| !m.trim().is_empty()) else {
+        return Ok(());
+    };
+
+    let spec = cache
+        .load_or_read(path)
+        .map_err(|err| anyhow!("Failed to load provider spec {}: {}", path.display(), err))?;
+
+    if spec
+        .models
+        .iter()
+        .any(|entry| entry.id.eq_ignore_ascii_case(model_id))
+    {
+        return Ok(());
+    }
+
+    let available: Vec<String> = spec.models.iter().map(|m| m.id.clone()).collect();
+    if available.is_empty() {
+        return Err(anyhow!(
+            "Provider spec {} does not list any models; cannot validate --model {}",
+            path.display(),
+            model_id
+        ));
+    }
+
+    Err(anyhow!(
+        "Model '{}' not available in {}. Available models: {}",
+        model_id,
+        path.display(),
+        available.join(", ")
+    ))
+}
+
+fn resolve_provider_from_dir(
+    dir: &Path,
+    model: Option<&str>,
+    cache: &ProviderCache,
+) -> Result<PathBuf> {
+    let candidates = collect_provider_candidates(dir, cache)?;
+    if candidates.is_empty() {
+        return Err(anyhow!(
+            "No provider specifications found under {}",
+            dir.display()
+        ));
+    }
+
+    if let Some(model_id) = model.filter(|m| !m.trim().is_empty()) {
+        if let Some(candidate) = candidates.iter().find(|candidate| {
+            candidate
+                .models
+                .iter()
+                .any(|id| id.eq_ignore_ascii_case(model_id))
+        }) {
+            return Ok(candidate.path.clone());
+        }
+
+        let available = collect_unique_models(&candidates);
+        let provider_name = dir
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(|name| name.to_string())
+            .unwrap_or_else(|| dir.to_string_lossy().into_owned());
+
+        if available.is_empty() {
+            return Err(anyhow!(
+                "Model '{}' not found for provider '{}'. Specify a provider spec path instead.",
+                model_id,
+                provider_name
+            ));
+        }
+
+        return Err(anyhow!(
+            "Model '{}' not found for provider '{}'. Available models: {}",
+            model_id,
+            provider_name,
+            available.join(", ")
+        ));
+    }
+
+    if let Some(candidate) = pick_default_candidate(&candidates) {
+        return Ok(candidate.path.clone());
+    }
+
+    Err(anyhow!(
+        "Unable to determine a default spec for {}. Pass --model to disambiguate.",
+        dir.display()
+    ))
+}
+
+fn collect_provider_candidates(
+    dir: &Path,
+    cache: &ProviderCache,
+) -> Result<Vec<ProviderCandidate>> {
+    let mut stack = vec![dir.to_path_buf()];
+    let mut candidates = Vec::new();
+
+    while let Some(current) = stack.pop() {
+        for entry in fs::read_dir(&current)
+            .with_context(|| format!("Failed to read provider directory: {}", current.display()))?
+        {
+            let entry = entry.with_context(|| {
+                format!("Failed to read provider entry under {}", current.display())
+            })?;
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if !is_spec_file(&path) {
+                continue;
+            }
+
+            let spec = cache.load_or_read(&path).map_err(|err| {
+                anyhow!("Failed to load provider spec {}: {}", path.display(), err)
+            })?;
+
+            let models = spec.models.iter().map(|m| m.id.clone()).collect();
+            candidates.push(ProviderCandidate { path, models });
+        }
+    }
+
+    Ok(candidates)
+}
+
+fn is_spec_file(path: &Path) -> bool {
+    let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+
+    if file_name.starts_with('_') || file_name.ends_with(".md") {
+        return false;
+    }
+
+    matches!(
+        path.extension()
+            .and_then(|ext| ext.to_str())
+            .map(|ext| matches!(ext, "yaml" | "yml" | "json")),
+        Some(true)
+    )
+}
+
+fn pick_default_candidate(candidates: &[ProviderCandidate]) -> Option<&ProviderCandidate> {
+    if candidates.len() == 1 {
+        return candidates.first();
+    }
+
+    let is_named = |candidate: &ProviderCandidate, target: &str| {
+        candidate
+            .path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(|name| name.eq_ignore_ascii_case(target))
+            .unwrap_or(false)
+    };
+
+    if let Some(candidate) = candidates.iter().find(|c| is_named(c, "base.yaml")) {
+        return Some(candidate);
+    }
+    if let Some(candidate) = candidates.iter().find(|c| is_named(c, "base.yml")) {
+        return Some(candidate);
+    }
+    if let Some(candidate) = candidates.iter().find(|c| is_named(c, "chat.yaml")) {
+        return Some(candidate);
+    }
+    if let Some(candidate) = candidates.iter().find(|c| is_named(c, "chat.yml")) {
+        return Some(candidate);
+    }
+
+    candidates
+        .iter()
+        .min_by_key(|candidate| candidate.path.to_string_lossy().to_ascii_lowercase())
+}
+
+fn collect_unique_models(candidates: &[ProviderCandidate]) -> Vec<String> {
+    let mut models: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for candidate in candidates {
+        for model in &candidate.models {
+            models.insert(model.clone());
+        }
+    }
+    models.into_iter().collect()
+}
+
+fn locate_providers_dir() -> Result<PathBuf> {
+    if let Ok(dir) = std::env::var("SPECADO_PROVIDERS_DIR") {
+        let path = PathBuf::from(dir);
+        if path.is_dir() {
+            return Ok(path);
+        }
+        return Err(anyhow!(
+            "SPECADO_PROVIDERS_DIR points to {}, which is not a directory",
+            path.display()
+        ));
+    }
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace_dir = manifest_dir.join("../specado-providers/providers");
+    if workspace_dir.is_dir() {
+        return Ok(workspace_dir);
+    }
+
+    let repo_relative = PathBuf::from("crates/specado-providers/providers");
+    if repo_relative.is_dir() {
+        return Ok(repo_relative);
+    }
+
+    Err(anyhow!(
+        "Unable to locate provider catalog. Set SPECADO_PROVIDERS_DIR or pass a provider spec path."
+    ))
+}
+
+fn list_available_providers(root: &Path) -> Result<Vec<String>> {
+    let mut providers = Vec::new();
+    for entry in fs::read_dir(root)
+        .with_context(|| format!("Failed to read providers directory: {}", root.display()))?
+    {
+        let entry =
+            entry.with_context(|| format!("Failed to read entry under {}", root.display()))?;
+        let path = entry.path();
+        if path.is_dir() {
+            if let Some(name) = path.file_name().and_then(|name| name.to_str()) {
+                providers.push(name.to_string());
+            }
+        }
+    }
+    providers.sort_unstable();
+    Ok(providers)
+}
+
+struct ProviderCandidate {
+    path: PathBuf,
+    models: Vec<String>,
 }
 
 #[derive(Args, Default, Clone)]

--- a/crates/specado-cli/src/main.rs
+++ b/crates/specado-cli/src/main.rs
@@ -2,7 +2,8 @@ use anyhow::{anyhow, Context, Result};
 use clap::{Args, Parser, Subcommand};
 use colored::*;
 use specado_core::{
-    execute, translate as core_translate, LossinessLevel, LossinessReport, PromptSpec, ProviderSpec,
+    execute, translate as core_translate, LossinessLevel, LossinessReport, Message, MessageRole,
+    PromptSpec, ProviderSpec, ResponseConfig, SamplingConfig, StrictMode,
 };
 use specado_schemas::get_validator;
 use std::fs;
@@ -25,6 +26,13 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Ask a quick question using the default provider/model
+    Ask {
+        /// The user prompt to send to the model
+        prompt: String,
+        #[command(flatten)]
+        runtime: RuntimeOptions,
+    },
     /// Validate a prompt or provider specification against the schemas
     Validate {
         #[arg(long)]
@@ -55,6 +63,7 @@ async fn main() {
     let cli = Cli::parse();
 
     let result = match cli.command {
+        Commands::Ask { prompt, runtime } => ask_command(prompt, runtime).await,
         Commands::Validate { spec } => validate_command(spec).await,
         Commands::Preview {
             prompt,
@@ -96,6 +105,50 @@ async fn validate_command(spec_path: PathBuf) -> Result<()> {
             .map_err(|e| anyhow!("Prompt spec invalid: {}", e))?;
         println!("{} Prompt spec is valid", "✓".green().bold());
     }
+
+    Ok(())
+}
+
+async fn ask_command(prompt: String, runtime: RuntimeOptions) -> Result<()> {
+    let provider_path = default_provider_path()?;
+
+    #[cfg(feature = "hot-reload")]
+    apply_hot_reload_config(&runtime, &provider_path);
+
+    #[cfg(feature = "audit-logging")]
+    let audit_context = build_audit_context(&runtime)?;
+
+    let prompt_spec = PromptSpec {
+        version: "1".to_string(),
+        messages: vec![
+            Message {
+                role: MessageRole::System,
+                content: "You are a helpful assistant.".to_string(),
+            },
+            Message {
+                role: MessageRole::User,
+                content: prompt,
+            },
+        ],
+        sampling: SamplingConfig::default(),
+        response: ResponseConfig::default(),
+        tools: Vec::new(),
+        tool_choice: None,
+        strict_mode: StrictMode::Warn,
+        metadata: Default::default(),
+    };
+
+    let response = execute(
+        prompt_spec,
+        provider_path
+            .to_str()
+            .ok_or_else(|| anyhow!("Provider path contains invalid UTF-8"))?,
+        #[cfg(feature = "audit-logging")]
+        audit_context,
+    )
+    .await?;
+
+    println!("{}", response.content.trim());
 
     Ok(())
 }
@@ -164,6 +217,28 @@ fn parse_to_json_value(content: &str, path: &Path) -> Result<serde_json::Value> 
             Err(_) => Ok(serde_yaml::from_str(content)?),
         }
     }
+}
+
+fn default_provider_path() -> Result<PathBuf> {
+    if let Ok(path) = std::env::var("SPECADO_DEFAULT_PROVIDER") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Ok(path);
+        }
+        return Err(anyhow!(
+            "Provider path specified via SPECADO_DEFAULT_PROVIDER does not exist: {}",
+            path.display()
+        ));
+    }
+
+    let fallback = PathBuf::from("crates/specado-providers/providers/openai/gpt-5/base.yaml");
+    if fallback.exists() {
+        return Ok(fallback);
+    }
+
+    Err(anyhow!(
+        "Default provider spec not found. Set SPECADO_DEFAULT_PROVIDER to a valid provider YAML."
+    ))
 }
 
 #[derive(Args, Default, Clone)]

--- a/crates/specado-cli/tests/cli.rs
+++ b/crates/specado-cli/tests/cli.rs
@@ -63,6 +63,59 @@ constraints:
     )
 }
 
+fn provider_yaml_with_models(
+    provider: &str,
+    models: &[&str],
+    url: &str,
+    token_env: &str,
+) -> String {
+    let models_block = models
+        .iter()
+        .map(|id| format!("  - id: {}", id))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        r#"provider: {provider}
+interface: text.generate
+contract_version: "1.0.0"
+
+auth:
+  type: bearer
+  token_env: {token_env}
+
+models:
+{models_block}
+
+endpoints:
+  chat:
+    method: POST
+    url: {url}
+    headers:
+      content-type: application/json
+
+mappings:
+  request:
+    - from: $.messages
+      to: $.body.messages
+  response:
+    - from: $.data.content
+      to: content
+    - from: $.data.finish_reason
+      to: finish_reason
+
+constraints:
+  supports:
+    json_mode: true
+    tools: true
+"#,
+        provider = provider,
+        models_block = models_block,
+        url = url,
+        token_env = token_env
+    )
+}
+
 #[test]
 fn validate_prompt_and_provider() {
     let dir = TempDir::new().expect("temp dir");
@@ -215,4 +268,74 @@ fn ask_uses_default_provider_for_single_turn() {
     mock.assert_hits(1);
     std::env::remove_var("SPECADO_DEFAULT_PROVIDER");
     std::env::remove_var(token_env);
+}
+
+#[test]
+fn ask_provider_and_model_flags_select_catalog_spec() {
+    let dir = TempDir::new().expect("temp dir");
+    let catalog_root = dir.path().join("providers");
+    std::fs::create_dir_all(&catalog_root.join("flag-provider")).expect("catalog provider dir");
+
+    let server = MockServer::start();
+    let token_env = "SPECADO_FLAG_TOKEN";
+    std::env::set_var(token_env, "flag-secret");
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/chat")
+            .header("authorization", "Bearer flag-secret");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "data": {
+                    "content": "flagged response",
+                    "finish_reason": "stop"
+                }
+            }));
+    });
+
+    let provider_yaml = provider_yaml_with_models(
+        "flag-provider",
+        &["test-model", "alternate-model"],
+        &server.url("/chat"),
+        token_env,
+    );
+    let provider_spec_path = catalog_root.join("flag-provider").join("catalog.yaml");
+    std::fs::write(&provider_spec_path, provider_yaml).expect("write provider spec");
+
+    std::env::set_var("SPECADO_PROVIDERS_DIR", &catalog_root);
+
+    let mut cmd = Command::cargo_bin("specado").expect("binary");
+    cmd.env("NO_COLOR", "1")
+        .arg("ask")
+        .arg("Hello flags")
+        .arg("--provider")
+        .arg("flag-provider")
+        .arg("--model")
+        .arg("test-model");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("flagged response"));
+
+    mock.assert_hits(1);
+    std::env::remove_var("SPECADO_PROVIDERS_DIR");
+    std::env::remove_var(token_env);
+}
+
+#[test]
+fn ask_model_flag_requires_provider() {
+    std::env::remove_var("SPECADO_PROVIDERS_DIR");
+    std::env::remove_var("SPECADO_DEFAULT_PROVIDER");
+
+    let mut cmd = Command::cargo_bin("specado").expect("binary");
+    cmd.env("NO_COLOR", "1")
+        .arg("ask")
+        .arg("Hello there")
+        .arg("--model")
+        .arg("gpt-5");
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("--model requires --provider"));
 }

--- a/crates/specado-cli/tests/cli.rs
+++ b/crates/specado-cli/tests/cli.rs
@@ -28,6 +28,8 @@ fn sample_prompt_json() -> serde_json::Value {
 fn sample_provider_yaml(url: &str, token_env: &str) -> String {
     format!(
         r#"provider: test
+interface: text.generate
+contract_version: "1.0.0"
 auth:
   type: bearer
   token_env: {token_env}
@@ -170,5 +172,47 @@ fn run_executes_against_provider() {
         .stdout(predicate::str::contains("hi from cli"));
 
     mock.assert_hits(1);
+    std::env::remove_var(token_env);
+}
+
+#[test]
+fn ask_uses_default_provider_for_single_turn() {
+    let dir = TempDir::new().expect("temp dir");
+
+    let server = MockServer::start();
+    let token_env = "SPECADO_ASK_TOKEN";
+    std::env::set_var(token_env, "ask-secret");
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/chat")
+            .header("authorization", "Bearer ask-secret");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "data": {
+                    "content": "hi from ask",
+                    "finish_reason": "stop"
+                }
+            }));
+    });
+
+    let provider_path = write_file(
+        &dir,
+        "provider.yaml",
+        sample_provider_yaml(&server.url("/chat"), token_env).as_str(),
+    );
+
+    std::env::set_var("SPECADO_DEFAULT_PROVIDER", &provider_path);
+
+    let mut cmd = Command::cargo_bin("specado").expect("binary");
+    cmd.env("NO_COLOR", "1").arg("ask").arg("Hello there");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("hi from ask"));
+
+    mock.assert_hits(1);
+    std::env::remove_var("SPECADO_DEFAULT_PROVIDER");
     std::env::remove_var(token_env);
 }

--- a/crates/specado-core/src/hot_reload.rs
+++ b/crates/specado-core/src/hot_reload.rs
@@ -86,16 +86,14 @@ fn merge_values(base: &mut JsonValue, overlay: &JsonValue) {
 }
 
 fn load_overlays(spec_path: &Path) -> Result<Vec<OverlaySpec>> {
-    let overlays_dir = spec_path
-        .ancestors()
-        .find_map(|ancestor| {
-            let candidate = ancestor.join("overlays");
-            if candidate.is_dir() {
-                Some(candidate)
-            } else {
-                None
-            }
-        });
+    let overlays_dir = spec_path.ancestors().find_map(|ancestor| {
+        let candidate = ancestor.join("overlays");
+        if candidate.is_dir() {
+            Some(candidate)
+        } else {
+            None
+        }
+    });
 
     let overlays_dir = match overlays_dir {
         Some(dir) => dir,
@@ -284,7 +282,7 @@ impl ProviderCache {
         let mut visited = HashSet::new();
         let merged_value = load_spec_value(&canonical, &mut visited)?;
         let overlays = load_overlays(&canonical)?;
-    let merged_value = merge_overlays(merged_value, overlays)?;
+        let merged_value = merge_overlays(merged_value, overlays)?;
         let mut spec: ProviderSpec = serde_json::from_value(merged_value)
             .map_err(|e| Error::Config(format!("Failed to parse provider spec: {}", e)))?;
         spec.inherits = None;

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -19,11 +19,22 @@ This guide walks through using Specado from the command line, Python, and Node.j
 ```
 
 ## 2. CLI walkthrough
-The CLI lives in `crates/specado-cli` and exposes `validate`, `preview`, and `run` subcommands. The examples below reference the sample prompt and provider specs added under `examples/`.
+The CLI lives in `crates/specado-cli` and exposes `ask`, `validate`, `preview`, and `run` subcommands. The examples below reference the sample prompt and provider specs added under `examples/`.
 
 ```sh
 # build the CLI binary
 cargo build -p specado-cli
+
+# single-turn question with the default provider/model
+OPENAI_API_KEY=sk-your-key \
+./target/debug/specado ask "What is Specado?"
+
+# target a specific provider/model from the catalog
+OPENAI_API_KEY=sk-your-key \
+./target/debug/specado ask \
+  "Explain the neutral interface taxonomy" \
+  --provider openai \
+  --model gpt-5
 
 # validate a provider or prompt spec
 ./target/debug/specado validate --spec crates/specado-providers/providers/openai/gpt-5/base.yaml


### PR DESCRIPTION
## Summary
- add provider/model flags to ask CLI command
- resolve provider specs from catalog or explicit paths with validation
- document ask usage and cover catalog scenarios with CLI tests

## Changes
- add provider resolution helpers and model validation to CLI
- extend CLI integration tests covering provider flags
- document ask usage and ensure provider catalog path detection
- tidy overlay loader formatting after fmt

## Testing
- [x] cargo fmt
- [x] cargo clippy -- -D warnings
- [x] cargo test --workspace

## Related Issues
Closes #100
