### PR TITLE
feat(cli): preload chat history in interactive ask

### DIFF
--- a/crates/specado-cli/src/main.rs
+++ b/crates/specado-cli/src/main.rs
@@ -43,6 +43,9 @@ enum Commands {
         /// Start an interactive chat session that preserves history
         #[arg(long, alias = "chat")]
         interactive: bool,
+        /// Load prior conversation history from a PromptSpec or messages file
+        #[arg(long = "messages-file", value_name = "PATH", requires = "interactive")]
+        messages_file: Option<PathBuf>,
         #[command(flatten)]
         runtime: RuntimeOptions,
     },
@@ -81,8 +84,9 @@ async fn main() {
             provider,
             model,
             interactive,
+            messages_file,
             runtime,
-        } => ask_command(prompt, provider, model, interactive, runtime).await,
+        } => ask_command(prompt, provider, model, interactive, messages_file, runtime).await,
         Commands::Validate { spec } => validate_command(spec).await,
         Commands::Preview {
             prompt,
@@ -133,6 +137,7 @@ async fn ask_command(
     provider_flag: Option<String>,
     model_flag: Option<String>,
     interactive: bool,
+    messages_file: Option<PathBuf>,
     runtime: RuntimeOptions,
 ) -> Result<()> {
     if !interactive && prompt.as_ref().map(|p| p.trim().is_empty()).unwrap_or(true) {
@@ -147,6 +152,13 @@ async fn ask_command(
     apply_hot_reload_config(&runtime, &provider_path);
 
     if interactive {
+        let mut history = if let Some(path) = messages_file {
+            load_history_messages(&path)?
+        } else {
+            Vec::new()
+        };
+        ensure_system_message(&mut history);
+
         let provider_spec = ProviderCache::new()
             .load_or_read(&provider_path)
             .map_err(|err| {
@@ -156,7 +168,7 @@ async fn ask_command(
                     err
                 )
             })?;
-        run_interactive_chat(prompt, &provider_path, &provider_spec, &runtime).await?;
+        run_interactive_chat(prompt, history, &provider_path, &provider_spec, &runtime).await?;
     } else {
         let mut messages = base_system_messages();
         messages.push(Message {
@@ -572,6 +584,60 @@ fn base_system_messages() -> Vec<Message> {
     }]
 }
 
+fn ensure_system_message(messages: &mut Vec<Message>) {
+    let has_system = messages
+        .iter()
+        .any(|message| matches!(message.role, MessageRole::System));
+    if !has_system {
+        messages.insert(
+            0,
+            Message {
+                role: MessageRole::System,
+                content: "You are a helpful assistant.".to_string(),
+            },
+        );
+    }
+}
+
+fn load_history_messages(path: &Path) -> Result<Vec<Message>> {
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read messages file: {}", path.display()))?;
+
+    if content.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let value = parse_to_json_value(&content, path)?;
+
+    if let Some(messages_value) = value.get("messages") {
+        let messages: Vec<Message> =
+            serde_json::from_value(messages_value.clone()).map_err(|err| {
+                anyhow!(
+                    "Failed to parse 'messages' array in {}: {}",
+                    path.display(),
+                    err
+                )
+            })?;
+        return Ok(messages);
+    }
+
+    if value.is_array() {
+        let messages: Vec<Message> = serde_json::from_value(value).map_err(|err| {
+            anyhow!(
+                "Failed to parse messages array in {}: {}",
+                path.display(),
+                err
+            )
+        })?;
+        return Ok(messages);
+    }
+
+    Err(anyhow!(
+        "Messages file {} must be a PromptSpec with a 'messages' array or an array of messages.",
+        path.display()
+    ))
+}
+
 fn build_prompt_spec(messages: &[Message]) -> PromptSpec {
     PromptSpec {
         version: "1".to_string(),
@@ -640,6 +706,7 @@ fn warn_if_context_near_limit(messages: &[Message], provider: &ProviderSpec) {
 
 async fn run_interactive_chat(
     initial_prompt: Option<String>,
+    mut messages: Vec<Message>,
     provider_path: &Path,
     provider_spec: &ProviderSpec,
     runtime: &RuntimeOptions,
@@ -649,7 +716,9 @@ async fn run_interactive_chat(
         "Starting interactive chat.".cyan()
     );
 
-    let mut messages = base_system_messages();
+    if !messages.is_empty() {
+        warn_if_context_near_limit(&messages, provider_spec);
+    }
 
     if let Some(initial) = initial_prompt {
         if !initial.trim().is_empty() {

--- a/crates/specado-cli/tests/cli.rs
+++ b/crates/specado-cli/tests/cli.rs
@@ -377,3 +377,101 @@ fn ask_interactive_chat_session_handles_multiple_turns() {
 
     mock.assert_hits(2);
 }
+
+#[test]
+fn ask_interactive_uses_messages_file_history() {
+    let dir = TempDir::new().expect("temp dir");
+
+    let server = MockServer::start();
+    let token_env = "SPECADO_HISTORY_TOKEN";
+    let provider_path = write_file(
+        &dir,
+        "provider.yaml",
+        sample_provider_yaml(&server.url("/chat"), token_env).as_str(),
+    );
+
+    let history_path = write_file(
+        &dir,
+        "history.json",
+        &serde_json::to_string_pretty(&json!({
+            "messages": [
+                {"role": "system", "content": "You are tracking a project."},
+                {"role": "user", "content": "Earlier question context"},
+                {"role": "assistant", "content": "Previous assistant response"}
+            ]
+        }))
+        .unwrap(),
+    );
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/chat")
+            .header("authorization", "Bearer history-secret")
+            .body_contains("Earlier question context")
+            .body_contains("Previous assistant response")
+            .body_contains("Bring me up to speed");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "data": {
+                    "content": "Continuing from history",
+                    "finish_reason": "stop"
+                }
+            }));
+    });
+
+    let mut cmd = Command::cargo_bin("specado").expect("binary");
+    cmd.env("NO_COLOR", "1")
+        .env(token_env, "history-secret")
+        .arg("ask")
+        .arg("--interactive")
+        .arg("--provider")
+        .arg(&provider_path)
+        .arg("--messages-file")
+        .arg(&history_path)
+        .arg("Bring me up to speed")
+        .write_stdin(":exit\n");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Continuing from history"));
+
+    mock.assert_hits(1);
+}
+
+#[test]
+fn ask_interactive_rejects_invalid_messages_file() {
+    let dir = TempDir::new().expect("temp dir");
+
+    let invalid_path = write_file(&dir, "invalid.yaml", "not: messages");
+
+    let server = MockServer::start();
+    let token_env = "SPECADO_INVALID_TOKEN";
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/chat");
+        then.status(200).body("{}");
+    });
+
+    let provider_path = write_file(
+        &dir,
+        "provider.yaml",
+        sample_provider_yaml(&server.url("/chat"), token_env).as_str(),
+    );
+
+    let mut cmd = Command::cargo_bin("specado").expect("binary");
+    cmd.env("NO_COLOR", "1")
+        .env(token_env, "invalid-secret")
+        .arg("ask")
+        .arg("--interactive")
+        .arg("--provider")
+        .arg(&provider_path)
+        .arg("--messages-file")
+        .arg(&invalid_path)
+        .write_stdin(":exit\n");
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("Messages file"));
+
+    mock.assert_hits(0);
+}

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -39,6 +39,15 @@ OPENAI_API_KEY=sk-your-key \
   --interactive \
   "Walk me through the request pipeline"
 
+# resume an existing conversation from a messages file
+OPENAI_API_KEY=sk-your-key \
+./target/debug/specado ask \
+  --interactive \
+  --messages-file path/to/chat_history.json \
+  --provider openai \
+  --model gpt-5 \
+  "Continue where we left off"
+
 # target a specific provider/model from the catalog
 OPENAI_API_KEY=sk-your-key \
 ./target/debug/specado ask \
@@ -74,7 +83,17 @@ The helper script `examples/cli_preview.sh` wraps the preview command and docume
 > **Model metadata & overlays**
 > The sample prompt `examples/prompts/basic_chat.json` includes metadata that targets OpenAI's GPT-5 Responses API (`openai_model`, reasoning effort, verbosity, max output tokens) and Anthropic's Claude Sonnet 4.5 (`anthropic_model`, thinking configuration, and max tokens). Tweak these fields to match the models and limits available to your account. The provider specs declare neutral interfaces (see `docs/process/INTERFACE_TAXONOMY.md`), while per-adapter defaults live in `overlays/`. See `docs/process/PROVIDER_INHERITANCE.md` for the full field reference.
 
-When chatting interactively, Specado preserves the full conversation history and warns as you approach the provider’s context window. Use `:exit`, `:quit`, or `Ctrl+C` to leave the session at any time.
+When chatting interactively, Specado preserves the full conversation history and warns as you approach the provider’s context window. Use `:exit`, `:quit`, or `Ctrl+C` to leave the session at any time. You can preload history with `--messages-file <path>` using either a full PromptSpec document or a JSON/YAML array of messages:
+
+```json
+{
+  "messages": [
+    { "role": "system", "content": "You are a release assistant." },
+    { "role": "user", "content": "Summarise the findings so far." },
+    { "role": "assistant", "content": "We validated the configuration and prepared tests." }
+  ]
+}
+```
 
 ## 3. Python quickstart
 The Python bindings are published from `crates/specado-py` and surfaced to the Python package in `python/specado`. Use `maturin` to build the native extension in-place, then run the sample program in `examples/python_basic.py`.


### PR DESCRIPTION
## Summary
- add --messages-file support to specado ask interactive mode
- load PromptSpec/message arrays as history with system default fallback and context warnings
- extend CLI tests and quickstart docs to cover history preloading

## Changes
- allow ask to accept optional messages file, parse JSON/YAML, and ensure system messages exist
- reuse interactive loop for preloaded history, warning before provider context overflow
- add CLI tests for history loading/validation and document usage examples

## Testing
- [x] cargo fmt
- [x] cargo clippy -- -D warnings
- [x] cargo test --workspace

## Related Issues
Closes #102
