### PR TITLE
chore(cli): restore shell completion generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,6 +530,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75bf0b32ad2e152de789bb635ea4d3078f6b838ad7974143e99b99f45a04af4a"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2586,6 +2595,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "clap_complete",
  "colored",
  "httpmock",
  "predicates",

--- a/crates/specado-cli/Cargo.toml
+++ b/crates/specado-cli/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 anyhow = "1.0"
 clap.workspace = true
 colored.workspace = true
+clap_complete = "4.5"
 serde_json.workspace = true
 serde_yaml.workspace = true
 specado-core = { workspace = true, features = ["hot-reload", "audit-logging"] }

--- a/crates/specado-cli/src/main.rs
+++ b/crates/specado-cli/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Context, Result};
-use clap::{Args, Parser, Subcommand};
+use clap::CommandFactory;
+use clap::{Args, Parser, Subcommand, ValueEnum};
 use colored::*;
 use specado_core::{
     execute, translate as core_translate, LossinessLevel, LossinessReport, Message, MessageRole,
@@ -72,6 +73,12 @@ enum Commands {
         #[command(flatten)]
         runtime: RuntimeOptions,
     },
+    /// Generate shell completion scripts for supported shells
+    Completions {
+        /// Target shell to generate completions for
+        #[arg(value_enum)]
+        shell: CompletionShell,
+    },
 }
 
 #[tokio::main]
@@ -98,6 +105,7 @@ async fn main() {
             provider,
             runtime,
         } => run_command(prompt, provider, runtime).await,
+        Commands::Completions { shell } => completions_command(shell),
     };
 
     if let Err(err) = result {
@@ -577,6 +585,28 @@ struct ProviderCandidate {
     models: Vec<String>,
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+enum CompletionShell {
+    Bash,
+    Zsh,
+    Fish,
+    #[allow(clippy::enum_variant_names)]
+    Powershell,
+    Elvish,
+}
+
+impl CompletionShell {
+    fn to_clap_shell(self) -> clap_complete::Shell {
+        match self {
+            CompletionShell::Bash => clap_complete::Shell::Bash,
+            CompletionShell::Zsh => clap_complete::Shell::Zsh,
+            CompletionShell::Fish => clap_complete::Shell::Fish,
+            CompletionShell::Powershell => clap_complete::Shell::PowerShell,
+            CompletionShell::Elvish => clap_complete::Shell::Elvish,
+        }
+    }
+}
+
 fn base_system_messages() -> Vec<Message> {
     vec![Message {
         role: MessageRole::System,
@@ -597,6 +627,17 @@ fn ensure_system_message(messages: &mut Vec<Message>) {
             },
         );
     }
+}
+
+fn completions_command(shell: CompletionShell) -> Result<()> {
+    use clap_complete::generate;
+    use std::io;
+
+    let mut cmd = Cli::command();
+    let name = cmd.get_name().to_string();
+    generate(shell.to_clap_shell(), &mut cmd, name, &mut io::stdout());
+
+    Ok(())
 }
 
 fn load_history_messages(path: &Path) -> Result<Vec<Message>> {

--- a/crates/specado-cli/tests/cli.rs
+++ b/crates/specado-cli/tests/cli.rs
@@ -379,6 +379,25 @@ fn ask_interactive_chat_session_handles_multiple_turns() {
 }
 
 #[test]
+fn completions_generate_scripts() {
+    let mut bash_cmd = Command::cargo_bin("specado").expect("binary");
+    bash_cmd.env("NO_COLOR", "1").arg("completions").arg("bash");
+
+    bash_cmd
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty().not());
+
+    let mut zsh_cmd = Command::cargo_bin("specado").expect("binary");
+    zsh_cmd.env("NO_COLOR", "1").arg("completions").arg("zsh");
+
+    zsh_cmd
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("compdef"));
+}
+
+#[test]
 fn ask_interactive_uses_messages_file_history() {
     let dir = TempDir::new().expect("temp dir");
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -48,6 +48,10 @@ OPENAI_API_KEY=sk-your-key \
   --model gpt-5 \
   "Continue where we left off"
 
+# generate shell completions (Bash example)
+./target/debug/specado completions bash > ~/.local/share/specado/completions.bash
+echo 'source ~/.local/share/specado/completions.bash' >> ~/.bashrc
+
 # target a specific provider/model from the catalog
 OPENAI_API_KEY=sk-your-key \
 ./target/debug/specado ask \
@@ -94,6 +98,8 @@ When chatting interactively, Specado preserves the full conversation history and
   ]
 }
 ```
+
+Shell completions are available for Bash, Zsh, Fish, PowerShell, and Elvish. Use `specado completions <shell>` to print the script, then follow your shell’s standard installation instructions (see `scripts`, e.g., sourcing in your shell profile or placing under `/usr/local/share`).
 
 ## 3. Python quickstart
 The Python bindings are published from `crates/specado-py` and surfaced to the Python package in `python/specado`. Use `maturin` to build the native extension in-place, then run the sample program in `examples/python_basic.py`.


### PR DESCRIPTION
## Summary
- add a completions subcommand backed by clap_complete
- emit scripts for Bash/Zsh/Fish/PowerShell/Elvish and document install steps
- add CLI smoke tests covering completion generation outputs

## Changes
- introduce CompletionShell value enum and completions handler in CLI
- wire clap_complete dependency and tests verifying non-empty scripts
- refresh quickstart guide with usage instructions for shell completions

## Testing
- [x] cargo fmt
- [x] cargo clippy -- -D warnings
- [x] cargo test --workspace

## Related Issues
Closes #103
