### PR TITLE
feat: refresh examples demos

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -92,7 +92,7 @@ OPENAI_API_KEY=sk-your-key \
   --provider crates/specado-providers/providers/openai/gpt-5/base.yaml
 ```
 
-The helper script `examples/cli_preview.sh` wraps the preview command and documents the expected environment when you need a quick smoke test.
+The helper script `examples/cli_preview.sh` wraps the preview command and documents the expected environment when you need a quick smoke test. For a richer walkthrough, `examples/cli_demo.sh` previews and (when API keys are present) runs the reasoning/thinking prompts that also power the Python and Node demos.
 
 > **Model metadata & overlays**
 > The sample prompt `examples/prompts/basic_chat.json` includes metadata that targets OpenAI's GPT-5 Responses API (`openai_model`, reasoning effort, verbosity, max output tokens) and Anthropic's Claude Sonnet 4.5 (`anthropic_model`, thinking configuration, and max tokens). Tweak these fields to match the models and limits available to your account. The provider specs declare neutral interfaces (see `docs/process/INTERFACE_TAXONOMY.md`), while per-adapter defaults live in `overlays/`. Refer to `docs/PROVIDER_SPEC.md` for the full YAML schema and authoring guidelines, and `docs/process/PROVIDER_INHERITANCE.md` for inheritance patterns.

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,12 +4,47 @@ This directory contains runnable samples that mirror the quickstart in `docs/QUI
 
 ## Assets
 - `prompts/basic_chat.json` — Minimal chat prompt shared by all examples.
-- `cli_preview.sh` — Helper script that invokes `specado preview` with the sample assets.
-- `python_basic.py` — Python binding example using both the native client and the OpenAI compatibility shim.
-- `node_basic.mjs` — Node.js binding example that exercises the napi-based client.
+- `prompts/openai_reasoning.json` — GPT-5 prompt that exercises reasoning controls.
+- `prompts/anthropic_thinking.json` — Claude Sonnet prompt with thinking enabled.
+- `cli_preview.sh` — Minimal wrapper around `specado preview` for ad-hoc checks.
+- `cli_demo.sh` — Runs the reasoning/thinking prompts via `specado preview`/`run`.
+- `python_basic.py` — Python demo supporting `--scenario {openai-reasoning,anthropic-thinking}` plus OpenAI compatibility mode.
+- `node_basic.mjs` — Node.js demo with the same scenarios and optional audit/watch toggles.
 
 ## Usage
 Follow the instructions in the quickstart to build the CLI, Python extension, and Node module. Each script accepts optional flags to point at different specs, enable audit logging, or turn on watch plumbing.
+
+### CLI
+
+Ensure the CLI binary is built (`cargo build -p specado-cli`). Then:
+
+```sh
+./examples/cli_demo.sh
+```
+
+The script previews both demo prompts and executes live calls when `OPENAI_API_KEY`/`ANTHROPIC_API_KEY` are present. Set `SPECADO_BIN` to point at a custom binary if you prefer not to use `cargo run`.
+
+### Python
+
+After `maturin develop -m crates/specado-py/Cargo.toml`, invoke:
+
+```sh
+python examples/python_basic.py --scenario openai-reasoning
+python examples/python_basic.py --scenario anthropic-thinking
+```
+
+Add `--openai-compat` on the first command to exercise the compatibility shim.
+
+### Node.js
+
+Build the napi module (`(cd crates/specado-node && npm install && npm run build)`) and run:
+
+```sh
+node examples/node_basic.mjs --scenario openai-reasoning
+node examples/node_basic.mjs --scenario anthropic-thinking
+```
+
+Use `--audit` or `--watch` to toggle optional features.
 
 When adapting a sample for a new provider or model, consult `docs/PROVIDER_SPEC.md` for the spec format and metadata keys that need to be supplied in the prompt.
 

--- a/examples/cli_demo.sh
+++ b/examples/cli_demo.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Convenience wrapper that previews and optionally runs the reasoning/thinking sample prompts.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+SPECADO_BIN="${SPECADO_BIN:-}"
+if [[ -z "${SPECADO_BIN}" ]]; then
+  if [[ -x "$REPO_ROOT/target/debug/specado" ]]; then
+    SPECADO_BIN="$REPO_ROOT/target/debug/specado"
+  else
+    SPECADO_BIN="cargo run --quiet -p specado-cli --"
+  fi
+fi
+
+OPENAI_PROMPT="$REPO_ROOT/examples/prompts/openai_reasoning.json"
+OPENAI_SPEC="$REPO_ROOT/crates/specado-providers/providers/openai/gpt-5/base.yaml"
+
+ANTHROPIC_PROMPT="$REPO_ROOT/examples/prompts/anthropic_thinking.json"
+ANTHROPIC_SPEC="$REPO_ROOT/crates/specado-providers/providers/anthropic/claude-4.5/sonnet.yaml"
+
+run_cli() {
+  # shellcheck disable=SC2086
+  eval "$SPECADO_BIN" "$@"
+}
+
+echo "== Preview GPT-5 reasoning payload =="
+run_cli preview \
+  --prompt "$OPENAI_PROMPT" \
+  --provider "$OPENAI_SPEC"
+echo
+
+if [[ -n "${OPENAI_API_KEY:-}" ]]; then
+  echo "== Executing GPT-5 reasoning request =="
+  run_cli run \
+    --prompt "$OPENAI_PROMPT" \
+    --provider "$OPENAI_SPEC" \
+    --audit-target stdout
+else
+  echo "Skipping GPT-5 run: set OPENAI_API_KEY to hit the live provider."
+fi
+echo
+
+echo "== Preview Claude Sonnet thinking payload =="
+run_cli preview \
+  --prompt "$ANTHROPIC_PROMPT" \
+  --provider "$ANTHROPIC_SPEC"
+echo
+
+if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+  echo "== Executing Claude Sonnet thinking request =="
+  run_cli run \
+    --prompt "$ANTHROPIC_PROMPT" \
+    --provider "$ANTHROPIC_SPEC" \
+    --audit-target stdout
+else
+  echo "Skipping Claude Sonnet run: set ANTHROPIC_API_KEY to hit the live provider."
+fi
+echo
+
+echo "Done."

--- a/examples/node_basic.mjs
+++ b/examples/node_basic.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Minimal Specado Node example for Issue #50.
+// Specado Node demo showcasing reasoning (OpenAI) and thinking (Anthropic).
 
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
@@ -9,12 +9,28 @@ import specado from '../crates/specado-node/index.js';
 
 const { Client } = specado;
 
+const SCENARIOS = {
+  'openai-reasoning': {
+    description: 'GPT-5 reasoning controls',
+    provider: 'crates/specado-providers/providers/openai/gpt-5/base.yaml',
+    prompt: 'examples/prompts/openai_reasoning.json',
+    apiKey: 'OPENAI_API_KEY',
+  },
+  'anthropic-thinking': {
+    description: 'Claude Sonnet thinking mode',
+    provider: 'crates/specado-providers/providers/anthropic/claude-4.5/sonnet.yaml',
+    prompt: 'examples/prompts/anthropic_thinking.json',
+    apiKey: 'ANTHROPIC_API_KEY',
+  },
+};
+
 function printUsage() {
   console.log(`Usage: node examples/node_basic.mjs [options]
 
 Options:
-  --provider <path>   Provider spec (default: crates/specado-providers/providers/openai/gpt-5/base.yaml)
-  --prompt <path>     Prompt spec JSON/YAML (default: examples/prompts/basic_chat.json)
+  --scenario <name>   Demo to run (default: openai-reasoning)
+  --provider <path>   Provider spec (override scenario default)
+  --prompt <path>     Prompt spec JSON/YAML (override scenario default)
   --watch             Enable experimental watch plumbing
   --audit             Forward audit logs to stdout
   --redact <value>    Additional audit redaction pattern (repeatable)
@@ -24,8 +40,9 @@ Options:
 
 function parseArgs(argv) {
   const options = {
-    provider: 'crates/specado-providers/providers/openai/gpt-5/base.yaml',
-    prompt: 'examples/prompts/basic_chat.json',
+    scenario: 'openai-reasoning',
+    provider: undefined,
+    prompt: undefined,
     watch: false,
     audit: false,
     redact: [],
@@ -34,6 +51,9 @@ function parseArgs(argv) {
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     switch (arg) {
+      case '--scenario':
+        options.scenario = argv[++i] ?? options.scenario;
+        break;
       case '--provider':
         options.provider = argv[++i] ?? options.provider;
         break;
@@ -84,17 +104,26 @@ async function loadPrompt(filePath) {
   return JSON.parse(contents);
 }
 
-function warnIfNoApiKey() {
-  if (!process.env.OPENAI_API_KEY) {
-    console.warn('warning: OPENAI_API_KEY is not set. The provider call will likely fail.');
+function warnIfNoApiKey(varName) {
+  if (!varName) return;
+  if (!process.env[varName]) {
+    console.warn(`warning: ${varName} is not set. The provider call will likely fail.`);
   }
 }
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
-  const promptPayload = await loadPrompt(args.prompt);
+  const scenarioName = SCENARIOS[args.scenario] ? args.scenario : 'openai-reasoning';
+  if (scenarioName !== args.scenario) {
+    console.warn(`Unknown scenario '${args.scenario}', defaulting to openai-reasoning.`);
+  }
+  const scenario = SCENARIOS[scenarioName];
 
-  warnIfNoApiKey();
+  const providerPath = args.provider ?? scenario.provider;
+  const promptPath = args.prompt ?? scenario.prompt;
+  const promptPayload = await loadPrompt(promptPath);
+
+  warnIfNoApiKey(scenario.apiKey);
 
   const clientOptions = {};
   if (args.watch) {
@@ -104,9 +133,13 @@ async function main() {
     clientOptions.audit = { target: 'stdout', redact: args.redact.filter(Boolean) };
   }
 
-  const client = new Client(args.provider, Object.keys(clientOptions).length ? clientOptions : undefined);
+  const client = new Client(providerPath, Object.keys(clientOptions).length ? clientOptions : undefined);
   const response = await client.complete(promptPayload);
   console.log(JSON.stringify(response, null, 2));
+
+  console.error(
+    `\nCompleted scenario '${scenarioName}' (${scenario.description}) using provider ${providerPath} and prompt ${promptPath}`,
+  );
 }
 
 main().catch((error) => {

--- a/examples/prompts/anthropic_thinking.json
+++ b/examples/prompts/anthropic_thinking.json
@@ -1,0 +1,24 @@
+{
+  "version": "1",
+  "messages": [
+    {
+      "role": "system",
+      "content": "You are a pragmatic teammate. Think aloud before you answer, then provide a crisp summary."
+    },
+    {
+      "role": "user",
+      "content": "Draft a short daily update for the Specado demos migration work."
+    }
+  ],
+  "strict_mode": "Warn",
+  "metadata": {
+    "anthropic_model": "claude-sonnet-4-5-20250929",
+    "anthropic_max_tokens": 512,
+    "thinking": {
+      "type": "enabled",
+      "budget_tokens": 640
+    },
+    "anthropic_thinking_type": "enabled",
+    "anthropic_thinking_budget": 640
+  }
+}

--- a/examples/prompts/openai_reasoning.json
+++ b/examples/prompts/openai_reasoning.json
@@ -1,0 +1,29 @@
+{
+  "version": "1",
+  "messages": [
+    {
+      "role": "system",
+      "content": "You are a deliberate staff engineer who reasons step by step before sharing concise recommendations."
+    },
+    {
+      "role": "user",
+      "content": "Suggest three quick rituals that keep a remote engineering squad aligned without adding busywork."
+    }
+  ],
+  "sampling": {
+    "temperature": 0.3,
+    "top_p": 0.85,
+    "seed": 1337
+  },
+  "strict_mode": "Warn",
+  "metadata": {
+    "openai_model": "gpt-5",
+    "openai_max_output_tokens": 512,
+    "reasoning": {
+      "effort": "medium",
+      "budget_tokens": 1200
+    },
+    "openai_reasoning_effort": "medium",
+    "openai_text_verbosity": "low"
+  }
+}

--- a/examples/python_basic.py
+++ b/examples/python_basic.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Minimal Specado Python example for Issue #50.
+"""Specado Python demo covering reasoning (OpenAI) and thinking (Anthropic).
 
-The script loads the sample prompt in ``examples/prompts/basic_chat.json`` and executes
-it against the provider spec supplied on the command line. Build the native extension
-via ``maturin develop -m crates/specado-py/Cargo.toml`` before running this file.
+Build the native extension first via ``maturin develop -m crates/specado-py/Cargo.toml``.
+By default the script points at the richer demo prompts that ship with ``examples/``.
+Use ``--scenario`` to switch between GPT-5 reasoning and Claude Sonnet thinking flows.
 """
 
 from __future__ import annotations
@@ -25,6 +25,22 @@ from specado import Message as PromptMessage
 from specado.compat.openai import OpenAI
 
 
+SCENARIOS = {
+    "openai-reasoning": {
+        "provider": "crates/specado-providers/providers/openai/gpt-5/base.yaml",
+        "prompt": "examples/prompts/openai_reasoning.json",
+        "api_key": "OPENAI_API_KEY",
+        "description": "GPT-5 reasoning controls",
+    },
+    "anthropic-thinking": {
+        "provider": "crates/specado-providers/providers/anthropic/claude-4.5/sonnet.yaml",
+        "prompt": "examples/prompts/anthropic_thinking.json",
+        "api_key": "ANTHROPIC_API_KEY",
+        "description": "Claude Sonnet thinking mode",
+    },
+}
+
+
 def load_prompt(path: pathlib.Path) -> Dict[str, Any]:
     data = path.read_text()
     suffix = path.suffix.lower()
@@ -40,12 +56,13 @@ def load_prompt(path: pathlib.Path) -> Dict[str, Any]:
     return json.loads(data)
 
 
-def ensure_api_key() -> None:
-    if "OPENAI_API_KEY" not in os.environ:
-        print(
-            "warning: OPENAI_API_KEY is not set. The provider call will likely fail.",
-            file=sys.stderr,
-        )
+def ensure_api_key(var_name: str) -> None:
+    if var_name in os.environ:
+        return
+    print(
+        f"warning: {var_name} is not set. The provider call will likely fail.",
+        file=sys.stderr,
+    )
 
 
 def run_native_client(args: argparse.Namespace, prompt_payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -61,10 +78,12 @@ def run_native_client(args: argparse.Namespace, prompt_payload: Dict[str, Any]) 
 def run_openai_compat(args: argparse.Namespace, prompt_payload: Dict[str, Any]) -> Dict[str, Any]:
     client = OpenAI(args.provider)
     prompt = PromptSpec(
+        version=prompt_payload.get("version", "1"),
         messages=[
             PromptMessage(role=message["role"], content=message["content"])
             for message in prompt_payload["messages"]
-        ]
+        ],
+        strict_mode=prompt_payload.get("strict_mode", "Warn"),
     )
     completion = client.chat.completions.create(
         model=prompt_payload.get("model", "gpt-5"),
@@ -82,12 +101,15 @@ def run_openai_compat(args: argparse.Namespace, prompt_payload: Dict[str, Any]) 
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Run the Specado Python example")
+    parser = argparse.ArgumentParser(description="Run the Specado Python demo")
     parser.add_argument(
-        "--provider",
-        default="crates/specado-providers/providers/openai/gpt-5/base.yaml",
+        "--scenario",
+        choices=sorted(SCENARIOS),
+        default="openai-reasoning",
+        help="Select which demo prompt to execute",
     )
-    parser.add_argument("--prompt", default="examples/prompts/basic_chat.json")
+    parser.add_argument("--provider")
+    parser.add_argument("--prompt")
     parser.add_argument("--watch", action="store_true", help="Enable experimental watch plumbing")
     parser.add_argument("--audit", action="store_true", help="Send audit logs to stdout")
     parser.add_argument(
@@ -102,17 +124,32 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    prompt_path = pathlib.Path(args.prompt)
+    scenario = SCENARIOS[args.scenario]
+    provider_path = args.provider or scenario["provider"]
+    prompt_path_value = args.prompt or scenario["prompt"]
+
+    args.provider = provider_path
+    args.prompt = prompt_path_value
+
+    prompt_path = pathlib.Path(prompt_path_value)
     prompt_payload = load_prompt(prompt_path)
 
-    ensure_api_key()
+    ensure_api_key(scenario["api_key"])
 
     if args.openai_compat:
+        if args.scenario != "openai-reasoning":
+            raise SystemExit("OpenAI compatibility mode only works with the GPT-5 scenario.")
         response = run_openai_compat(args, prompt_payload)
     else:
         response = run_native_client(args, prompt_payload)
 
     print(json.dumps(response, indent=2))
+
+
+    print(
+        f"\nCompleted scenario '{args.scenario}' ({scenario['description']}) using provider {provider_path} and prompt {prompt_path}",
+        file=sys.stderr,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add reasoning/thinking demo prompts and a CLI helper that runs them end-to-end
- expand python/node samples with scenario-aware defaults and richer status output
- document the new workflows across examples README and quickstart

Closes #111

## Testing
- cargo test --workspace