### PR TITLE
feat: cross-language env bootstrap and demo logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,6 +683,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,6 +699,18 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -719,6 +740,12 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "either"
@@ -1775,6 +1802,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2597,6 +2630,8 @@ dependencies = [
  "clap",
  "clap_complete",
  "colored",
+ "dirs",
+ "dotenvy",
  "httpmock",
  "predicates",
  "serde_json",
@@ -3307,6 +3342,15 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -3339,6 +3383,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -3376,6 +3435,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3388,6 +3453,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3397,6 +3468,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3424,6 +3501,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3433,6 +3516,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3448,6 +3537,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3457,6 +3552,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,179 @@
-# specado
+# Specado
 
-Specado is a spec-driven orchestration layer that unifies prompt execution across multiple LLM providers.
+Specado is a spec-driven orchestration layer that unifies prompt execution across multiple LLM providers. It provides a single, consistent interface for interacting with a wide range of language models, and allows you to define and customize providers and models using simple YAML specifications.
 
-- Quickstart guide: [`docs/QUICKSTART.md`](docs/QUICKSTART.md)
-- Migration notes (draft): [`docs/MIGRATION.md`](docs/MIGRATION.md)
-- Sample assets: [`examples/`](examples/README.md)
+## Key Features
+
+*   **Unified Interface**: A single, consistent API for interacting with multiple LLM providers, including OpenAI and Anthropic.
+*   **Spec-Driven Configuration**: Define and customize providers, models, and parameter mappings using simple, powerful YAML files. See the [Provider Spec Guide](docs/PROVIDER_SPEC.md) for more details.
+*   **Powerful CLI**: A user-friendly command-line interface with a rich set of features, including:
+    *   Single-turn queries with the `ask` command.
+    *   Interactive chat sessions with history.
+    *   Support for advanced provider features like OpenAI "reasoning" and Anthropic "thinking" modes.
+    *   Shell completion for Bash, Zsh, Fish, and more.
+*   **Python and Node.js Libraries**: Integrate Specado into your own applications with our easy-to-use Python and Node.js libraries.
+*   **Provider-Agnostic Design**: The core of Specado is provider-agnostic, allowing you to easily add new providers and models.
+
+## Installation
+
+_(Detailed installation instructions for different platforms will be added here once the project is packaged for distribution. For now, you will need to build from source.)_
+
+### Building from Source
+
+**Prerequisites:**
+
+*   Rust 1.75 or newer
+*   Node.js 18+
+*   Python 3.9+
+
+### Environment configuration
+
+Specado reads credentials from the following locations (in order):
+
+1. `~/.config/specado/.env` on Linux, `~/Library/Application Support/specado/.env` on macOS, or `%AppData%\specado\.env` on Windows. Create the directory if needed (e.g. `mkdir -p ~/.config/specado && chmod 700 ~/.config/specado` on Linux, `mkdir -p "$HOME/Library/Application Support/specado"` on macOS) and restrict the file (`chmod 600 …`).
+2. A `.env` file in the current working directory.
+3. Any variables already present in the process environment.
+
+The CLI, Python demo, and Node demo all follow this loading order. Once your keys are stored in the global config file you can still override them per-repo by adding a `.env` next to your prompts, or export them manually with `export OPENAI_API_KEY=...`.
+
+```sh
+# 1. Clone the repository
+git clone https://github.com/specado/specado.git
+cd specado
+
+# 2. Build the workspace
+cargo build --workspace
+```
+
+## CLI Usage
+
+The `specado` CLI is the primary way to interact with the system. The main binary is located at `target/debug/specado` after building from source.
+
+### `specado ask`
+
+The `ask` command is the main entrypoint for interacting with LLMs.
+
+**Single-Turn Query:**
+
+```sh
+./target/debug/specado ask "What is the meaning of life?"
+```
+
+**Interactive Chat:**
+
+```sh
+./target/debug/specado ask --interactive
+```
+
+**Flags:**
+
+*   `--provider <PROVIDER>`: Specify a provider to use (e.g., `openai`, `anthropic`).
+*   `--model <MODEL>`: Specify a model to use (e.g., `gpt-4o`, `claude-3.5-sonnet-20240620`).
+*   `--messages-file <PATH>`: Load a chat history from a JSON or YAML file.
+*   `--reason`: Enable advanced reasoning/thinking modes.
+
+### `specado completions`
+
+Generate shell completion scripts.
+
+```sh
+# Example for Bash
+./target/debug/specado completions bash > /usr/local/share/bash-completion/completions/specado
+```
+
+### `specado validate`
+
+Validate a provider or prompt spec file.
+
+```sh
+./target/debug/specado validate --spec crates/specado-providers/providers/openai/gpt-4/o.yaml
+```
+
+### `specado preview`
+
+Preview the translated payload for a given prompt and provider without making a network call.
+
+```sh
+./target/debug/specado preview --prompt examples/prompts/basic_chat.json --provider crates/specado-providers/providers/openai/gpt-4/o.yaml
+```
+
+### `specado run`
+
+Execute a prompt against a provider.
+
+```sh
+./target/debug/specado run --prompt examples/prompts/basic_chat.json --provider crates/specado-providers/providers/openai/gpt-4/o.yaml
+```
+
+## Programmatic Usage
+
+### Python
+
+**Installation:**
+
+```sh
+pip install maturin
+maturin develop -m crates/specado-py/Cargo.toml
+```
+
+**Usage:**
+
+```python
+from specado import Specado
+
+# Initialize the client
+client = Specado()
+
+# Make a simple request
+response = client.ask("Hello, world!")
+print(response.content)
+
+# Use a custom provider spec
+custom_client = Specado(provider_spec="/path/to/my_provider.yaml")
+response = custom_client.ask("Hello from my custom provider!")
+print(response.content)
+```
+
+### Node.js
+
+**Installation:**
+
+```sh
+(cd crates/specado-node && npm install && npm run build)
+```
+
+**Usage:**
+
+```javascript
+import { Specado } from 'specado';
+
+async function main() {
+  // Initialize the client
+  const client = new Specado();
+
+  // Make a simple request
+  const response = await client.ask("Hello, world!");
+  console.log(response.content);
+
+  // Use a custom provider spec
+  const customClient = new Specado({
+    providerSpec: "/path/to/my_provider.yaml"
+  });
+  const customResponse = await customClient.ask("Hello from my custom provider!");
+  console.log(customResponse.content);
+}
+
+main();
+```
+
+## Examples
+
+The `examples/` directory contains a set of runnable examples that demonstrate the features of Specado. See the [Examples README](examples/README.md) for more details.
+
+## Contributing
+
+Contributions are welcome! Please see the [GitHub Tracking Guidelines](docs/process/GITHUB_TRACKING.md) for information on our development process.
+
+## License
+
+This project is licensed under the terms of the [LICENSE](LICENSE) file.

--- a/crates/specado-cli/Cargo.toml
+++ b/crates/specado-cli/Cargo.toml
@@ -24,6 +24,8 @@ serde_yaml.workspace = true
 specado-core = { workspace = true, features = ["hot-reload", "audit-logging"] }
 specado-schemas.workspace = true
 tokio.workspace = true
+dirs = "5.0"
+dotenvy = "0.15"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/crates/specado-cli/src/commands.rs
+++ b/crates/specado-cli/src/commands.rs
@@ -1,6 +1,6 @@
 use crate::chat;
 use crate::cli::{CompletionShell, ReasonEffort, RuntimeOptions};
-use crate::io::{load_prompt_spec, load_provider_spec, parse_to_json_value};
+use crate::io::{load_prompt_spec, parse_to_json_value};
 use crate::resolver::resolve_provider_path;
 use crate::runtime;
 use anyhow::{anyhow, Context, Result};
@@ -50,7 +50,15 @@ pub async fn preview_command(
     runtime::apply_hot_reload_config(&runtime, &provider_path);
 
     let prompt = load_prompt_spec(&prompt_path)?;
-    let provider = load_provider_spec(&provider_path)?;
+    let provider = ProviderCache::new()
+        .load_or_read(&provider_path)
+        .map_err(|err| {
+            anyhow!(
+                "Failed to load provider spec {}: {}",
+                provider_path.display(),
+                err
+            )
+        })?;
 
     let (translated, lossiness) = core_translate(&prompt, &provider)?;
 

--- a/crates/specado-cli/src/io.rs
+++ b/crates/specado-cli/src/io.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Context, Result};
 use serde_json::Value as JsonValue;
-use specado_core::{PromptSpec, ProviderSpec};
+use specado_core::PromptSpec;
 use std::fs;
 use std::path::Path;
 
@@ -29,18 +29,6 @@ pub fn load_prompt_spec(path: &Path) -> Result<PromptSpec> {
         Ok(spec) => Ok(spec),
         Err(json_err) => serde_yaml::from_str(&content).map_err(|yaml_err| {
             anyhow!("Failed to parse prompt spec as JSON ({json_err}) or YAML ({yaml_err})")
-        }),
-    }
-}
-
-pub fn load_provider_spec(path: &Path) -> Result<ProviderSpec> {
-    let content = fs::read_to_string(path)
-        .with_context(|| format!("Failed to read provider spec: {}", path.display()))?;
-
-    match serde_yaml::from_str(&content) {
-        Ok(spec) => Ok(spec),
-        Err(yaml_err) => serde_json::from_str(&content).map_err(|json_err| {
-            anyhow!("Failed to parse provider spec as YAML ({yaml_err}) or JSON ({json_err})")
         }),
     }
 }

--- a/crates/specado-cli/src/main.rs
+++ b/crates/specado-cli/src/main.rs
@@ -8,10 +8,41 @@ mod runtime;
 use crate::cli::{Cli, Commands};
 use clap::Parser;
 use colored::Colorize;
+use std::path::PathBuf;
 use std::process;
+
+fn load_env() {
+    let mut errors = Vec::new();
+
+    if let Some(global) = config_env_path() {
+        if global.exists() {
+            if let Err(err) = dotenvy::from_path(&global) {
+                errors.push(format!("Failed to load {}: {}", global.display(), err));
+            }
+        }
+    }
+
+    if let Err(err) = dotenvy::dotenv_override() {
+        if !matches!(err, dotenvy::Error::Io(ref io_err) if io_err.kind() == std::io::ErrorKind::NotFound)
+        {
+            errors.push(format!("Failed to load .env: {}", err));
+        }
+    }
+
+    if !errors.is_empty() {
+        for error in errors {
+            eprintln!("{} {}", "warning:".yellow().bold(), error);
+        }
+    }
+}
+
+fn config_env_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|dir| dir.join("specado").join(".env"))
+}
 
 #[tokio::main]
 async fn main() {
+    load_env();
     let cli = Cli::parse();
 
     let result = match cli.command {

--- a/crates/specado-core/src/audit.rs
+++ b/crates/specado-core/src/audit.rs
@@ -120,6 +120,7 @@ impl AuditContext {
             latency_ms,
             status: AuditStatus::Success,
             error_kind: None,
+            error_message: None,
             lossiness: Some(lossiness.clone()),
             request_redacted: request,
             response_excerpt: Some(response_excerpt),
@@ -132,7 +133,12 @@ impl AuditContext {
         }
     }
 
-    pub fn record_error(&mut self, translated_request: Option<&Value>, error: &Error) {
+    pub fn record_error(
+        &mut self,
+        translated_request: Option<&Value>,
+        error: &Error,
+        response_excerpt: Option<&Value>,
+    ) {
         if !self.config.is_enabled() {
             return;
         }
@@ -149,9 +155,10 @@ impl AuditContext {
             latency_ms,
             status: AuditStatus::Error,
             error_kind: Some(error_to_kind(error)),
+            error_message: Some(error.to_string()),
             lossiness: None,
             request_redacted: request,
-            response_excerpt: None,
+            response_excerpt: response_excerpt.cloned(),
         };
 
         if let Some(logger) = self.logger.as_mut() {
@@ -276,6 +283,8 @@ struct AuditEvent {
     #[serde(skip_serializing_if = "Option::is_none")]
     error_kind: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    error_message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     lossiness: Option<LossinessReport>,
     request_redacted: Value,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -283,8 +292,8 @@ struct AuditEvent {
 }
 
 const DEFAULT_REDACTION: &[&str] = &[
-    "(?i)authorization",
-    "(?i)token",
+    "(?i)^authorization$",
+    "(?i)^bearer$",
     "(?i)secret",
     "(?i)api[-_]?key",
 ];
@@ -374,6 +383,6 @@ mod tests {
     #[test]
     fn audit_context_records_error_without_panic() {
         let mut ctx = AuditContext::new(AuditConfig::disabled());
-        ctx.record_error(None, &Error::StrictModeViolation);
+        ctx.record_error(None, &Error::StrictModeViolation, None);
     }
 }

--- a/crates/specado-core/src/lib.rs
+++ b/crates/specado-core/src/lib.rs
@@ -52,7 +52,7 @@ pub async fn execute(
         Err(err) => {
             #[cfg(feature = "audit-logging")]
             if let Some(ctx) = audit.as_mut() {
-                ctx.record_error(None, &err);
+                ctx.record_error(None, &err, None);
             }
             return Err(err);
         }
@@ -66,7 +66,7 @@ pub async fn execute(
     if prompt.strict_mode == StrictMode::Strict && lossiness.is_lossy {
         #[cfg(feature = "audit-logging")]
         if let Some(ctx) = audit.as_mut() {
-            ctx.record_error(Some(&translated), &Error::StrictModeViolation);
+            ctx.record_error(Some(&translated), &Error::StrictModeViolation, None);
         }
         return Err(Error::StrictModeViolation);
     }
@@ -96,7 +96,7 @@ pub async fn execute(
             let error = Error::Http(err);
             #[cfg(feature = "audit-logging")]
             if let Some(ctx) = audit.as_mut() {
-                ctx.record_error(Some(&translated), &error);
+                ctx.record_error(Some(&translated), &error, None);
             }
             return Err(error);
         }
@@ -107,13 +107,28 @@ pub async fn execute(
         let kind = map_status_to_provider_error(status);
         #[cfg(feature = "audit-logging")]
         if let Some(ctx) = audit.as_mut() {
+            let body_text = response.text().await.unwrap_or_default();
+            let body_value = if body_text.trim().is_empty() {
+                Value::Null
+            } else {
+                serde_json::from_str(&body_text).unwrap_or_else(|_| Value::String(body_text))
+            };
             ctx.record_error(
                 Some(&translated),
                 &Error::Provider {
                     provider: provider_spec.provider.clone(),
                     kind: kind.clone(),
                 },
+                Some(&body_value),
             );
+            return Err(Error::Provider {
+                provider: provider_spec.provider.clone(),
+                kind,
+            });
+        }
+        #[cfg(not(feature = "audit-logging"))]
+        {
+            let _ = response.text().await;
         }
         return Err(Error::Provider {
             provider: provider_spec.provider.clone(),

--- a/crates/specado-core/src/transformer/normalize.rs
+++ b/crates/specado-core/src/transformer/normalize.rs
@@ -26,7 +26,19 @@ pub fn normalize(raw: Value, provider: &ProviderSpec) -> Result<UniformResponse>
         match mapping.to.as_str() {
             "content" => {
                 if let Some(text) = value.as_str() {
-                    content = text.to_string();
+                    if !text.is_empty() {
+                        content = text.to_string();
+                    }
+                } else if let Some(array) = value.as_array() {
+                    let joined = array
+                        .iter()
+                        .filter_map(Value::as_str)
+                        .filter(|s| !s.is_empty())
+                        .collect::<Vec<_>>()
+                        .join(" ");
+                    if !joined.is_empty() {
+                        content = joined;
+                    }
                 }
             }
             "finish_reason" => {
@@ -138,6 +150,29 @@ mod tests {
         assert_eq!(response.content, "Hello");
         assert_eq!(response.finish_reason, FinishReason::Stop);
         assert_eq!(response.model, "gpt-4o");
+    }
+
+    #[test]
+    fn joins_array_content() {
+        let raw = json!({
+            "choices": [
+                {
+                    "message": {
+                        "content": [
+                            {"text": "Hello"},
+                            {"text": "world"}
+                        ]
+                    },
+                    "finish_reason": "stop"
+                }
+            ]
+        });
+
+        let mut provider = provider();
+        provider.mappings.response[0].from = "$.choices[0].message.content[*].text".into();
+
+        let response = normalize(raw, &provider).expect("normalize");
+        assert_eq!(response.content, "Hello world");
     }
 
     #[test]

--- a/crates/specado-providers/providers/openai/_base-chat-completions.yaml
+++ b/crates/specado-providers/providers/openai/_base-chat-completions.yaml
@@ -15,12 +15,16 @@ endpoints:
 
 mappings:
   request:
+    - from: "$.metadata.openai_model"
+      to: "$.model"
     - from: "$.messages"
       to: "$.messages"
     - from: "$.sampling.temperature"
       to: "$.temperature"
     - from: "$.sampling.top_p"
       to: "$.top_p"
+    - from: "$.metadata.openai_max_output_tokens"
+      to: "$.max_tokens"
   response:
     - from: "$.choices[0].message.content"
       to: "content"

--- a/crates/specado-providers/providers/openai/_base-responses.yaml
+++ b/crates/specado-providers/providers/openai/_base-responses.yaml
@@ -32,9 +32,11 @@ mappings:
     - from: "$.messages"
       to: "$.messages"
   response:
-    - from: "$.output[?(@.type=='message')].content[0].text"
+    - from: "$.output_text[0]"
       to: "content"
-    - from: "$.output[?(@.type=='message')].status"
+    - from: "$.output[?(@.type=='message')].content[*].text"
+      to: "content"
+    - from: "$.output[?(@.type=='message')].stop_reason"
       to: "finish_reason"
 
 constraints:

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,51 +1,53 @@
-# Examples Overview
+# Examples
 
-This directory contains runnable samples that mirror the quickstart in `docs/QUICKSTART.md` and support Issue #50 (Docs, Tests, Benches, Examples Scaffolding).
+This directory contains a set of examples to help you get started with Specado.
 
-## Assets
-- `prompts/basic_chat.json` — Minimal chat prompt shared by all examples.
-- `prompts/openai_reasoning.json` — GPT-5 prompt that exercises reasoning controls.
-- `prompts/anthropic_thinking.json` — Claude Sonnet prompt with thinking enabled.
-- `cli_preview.sh` — Minimal wrapper around `specado preview` for ad-hoc checks.
-- `cli_demo.sh` — Runs the reasoning/thinking prompts via `specado preview`/`run`.
-- `python_basic.py` — Python demo supporting `--scenario {openai-reasoning,anthropic-thinking}` plus OpenAI compatibility mode.
-- `node_basic.mjs` — Node.js demo with the same scenarios and optional audit/watch toggles.
+Before running these examples, please make sure you have followed the installation instructions in the main [README.md](../README.md). Specado looks for API keys in `~/.config/specado/.env` on Linux, `~/Library/Application Support/specado/.env` on macOS, and `%AppData%\specado\.env` on Windows before falling back to a local `.env`; create one of those files if you don't want to export variables manually (`mkdir -p ~/.config/specado` on Linux, `mkdir -p "$HOME/Library/Application Support/specado"` on macOS).
 
-## Usage
-Follow the instructions in the quickstart to build the CLI, Python extension, and Node module. Each script accepts optional flags to point at different specs, enable audit logging, or turn on watch plumbing.
+## CLI Demo
 
-### CLI
+The `cli_demo.sh` script demonstrates how to use the `specado` CLI to interact with the advanced features of different providers.
 
-Ensure the CLI binary is built (`cargo build -p specado-cli`). Then:
+### Usage
+
+The script relies on the same environment loading rules (global config, local `.env`, or exported variables). Set up at least one of those locations with `OPENAI_API_KEY` and `ANTHROPIC_API_KEY`.
 
 ```sh
 ./examples/cli_demo.sh
 ```
 
-The script previews both demo prompts and executes live calls when `OPENAI_API_KEY`/`ANTHROPIC_API_KEY` are present. Set `SPECADO_BIN` to point at a custom binary if you prefer not to use `cargo run`.
+## Python Example
 
-### Python
+The `python_basic.py` script shows how to use the Specado Python library.
 
-After `maturin develop -m crates/specado-py/Cargo.toml`, invoke:
+### Usage
 
 ```sh
+# Run the OpenAI reasoning demo
 python examples/python_basic.py --scenario openai-reasoning
+
+# Run the Anthropic thinking demo
 python examples/python_basic.py --scenario anthropic-thinking
 ```
 
-Add `--openai-compat` on the first command to exercise the compatibility shim.
+## Node.js Example
 
-### Node.js
+The `node_basic.mjs` script shows how to use the Specado Node.js library.
 
-Build the napi module (`(cd crates/specado-node && npm install && npm run build)`) and run:
+### Usage
 
 ```sh
+# Run the OpenAI reasoning demo
 node examples/node_basic.mjs --scenario openai-reasoning
+
+# Run the Anthropic thinking demo
 node examples/node_basic.mjs --scenario anthropic-thinking
 ```
 
-Use `--audit` or `--watch` to toggle optional features.
+## Prompts
 
-When adapting a sample for a new provider or model, consult `docs/PROVIDER_SPEC.md` for the spec format and metadata keys that need to be supplied in the prompt.
+This directory also contains the JSON prompt files that are used by the examples:
 
-These samples are intentionally lightweight; add new fixtures alongside them when demonstrating additional providers or prompt types.
+*   `prompts/basic_chat.json`: A minimal chat prompt.
+*   `prompts/openai_reasoning.json`: A prompt that demonstrates OpenAI's reasoning controls.
+*   `prompts/anthropic_thinking.json`: A prompt that demonstrates Anthropic's thinking mode.

--- a/examples/cli_demo.sh
+++ b/examples/cli_demo.sh
@@ -6,55 +6,173 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-SPECADO_BIN="${SPECADO_BIN:-}"
-if [[ -z "${SPECADO_BIN}" ]]; then
+if [[ -z "${SPECADO_BIN:-}" ]]; then
   if [[ -x "$REPO_ROOT/target/debug/specado" ]]; then
-    SPECADO_BIN="$REPO_ROOT/target/debug/specado"
+    SPECADO_BIN=("$REPO_ROOT/target/debug/specado")
   else
-    SPECADO_BIN="cargo run --quiet -p specado-cli --"
+    SPECADO_BIN=(cargo run --quiet -p specado-cli --)
   fi
+else
+  # Allow the user to provide a custom command (split on spaces intentionally)
+  read -r -a SPECADO_BIN <<<"$SPECADO_BIN"
 fi
 
 OPENAI_PROMPT="$REPO_ROOT/examples/prompts/openai_reasoning.json"
 OPENAI_SPEC="$REPO_ROOT/crates/specado-providers/providers/openai/gpt-5/base.yaml"
-
 ANTHROPIC_PROMPT="$REPO_ROOT/examples/prompts/anthropic_thinking.json"
 ANTHROPIC_SPEC="$REPO_ROOT/crates/specado-providers/providers/anthropic/claude-4.5/sonnet.yaml"
 
+config_env_path() {
+  case "${OSTYPE:-}" in
+    cygwin*|msys*|win32*)
+      local base="${APPDATA:-}"
+      if [[ -z "$base" ]]; then
+        base="$HOME/AppData/Roaming"
+      fi
+      printf '%s\n' "$base/specado/.env"
+      ;;
+    darwin*)
+      printf '%s\n' "$HOME/Library/Application Support/specado/.env"
+      ;;
+    *)
+      printf '%s\n' "${XDG_CONFIG_HOME:-$HOME/.config}/specado/.env"
+      ;;
+  esac
+}
+
+trim() {
+  local var="$1"
+  var="${var#"${var%%[![:space:]]*}"}"
+  var="${var%"${var##*[![:space:]]}"}"
+  printf '%s' "$var"
+}
+
+load_env_file() {
+  local file="$1"
+  local override="$2"
+  [[ -f "$file" ]] || return 0
+
+  while IFS= read -r raw || [[ -n "$raw" ]]; do
+    local line="${raw%%$'\r'}"
+    [[ -z "$line" || "${line#"${line%%[![:space:]]*}"}" == \#* || "$line" != *"="* ]] && continue
+    local key="${line%%=*}"
+    local value="${line#*=}"
+    key="$(trim "$key")"
+    value="$(trim "$value")"
+    [[ -z "$key" ]] && continue
+    if [[ "$override" == "true" || -z "${!key:-}" ]]; then
+      export "$key=$value"
+    fi
+  done < "$file"
+}
+
+load_env() {
+  local global_path
+  global_path="$(config_env_path)"
+  load_env_file "$global_path" "false"
+  load_env_file "$REPO_ROOT/.env" "true"
+}
+
+load_env
+
 run_cli() {
-  # shellcheck disable=SC2086
-  eval "$SPECADO_BIN" "$@"
+  "${SPECADO_BIN[@]}" "$@"
+}
+
+command_string() {
+  local args=("${SPECADO_BIN[@]}" "$@")
+  printf '%q ' "${args[@]}"
+}
+
+log_step() {
+  echo "--> $1"
+}
+
+print_preview() {
+  printf '%s\n' "$1"
+}
+
+print_response() {
+  local payload="$1"
+  local start_line
+  start_line=$(printf '%s\n' "$payload" | grep -n '{' | head -n1 | cut -d: -f1)
+  if [[ -z "$start_line" ]]; then
+    printf '%s\n' "$payload"
+    return
+  fi
+
+  if (( start_line > 1 )); then
+    printf '%s\n' "$payload" | head -n $((start_line-1))
+  fi
+
+  local json_block
+  json_block=$(printf '%s\n' "$payload" | tail -n +$start_line)
+
+  if command -v jq >/dev/null 2>&1; then
+    local content
+    content=$(echo "$json_block" | jq -r '(.content // .response_excerpt.content // empty)' 2>/dev/null)
+    if [[ -n "$content" && "$content" != "null" ]]; then
+      echo "--- Provider content ---"
+      echo "$content"
+      echo
+    fi
+    if parsed=$(echo "$json_block" | jq . 2>/dev/null); then
+      echo "$parsed"
+    else
+      echo "$json_block"
+    fi
+  else
+    echo "$json_block"
+  fi
 }
 
 echo "== Preview GPT-5 reasoning payload =="
-run_cli preview \
+log_step "Translating prompt to provider request"
+echo "Command: $(command_string preview --prompt "$OPENAI_PROMPT" --provider "$OPENAI_SPEC")"
+preview_output=$(run_cli preview \
   --prompt "$OPENAI_PROMPT" \
-  --provider "$OPENAI_SPEC"
+  --provider "$OPENAI_SPEC" 2>&1) || true
+print_preview "$preview_output"
 echo
 
 if [[ -n "${OPENAI_API_KEY:-}" ]]; then
   echo "== Executing GPT-5 reasoning request =="
-  run_cli run \
+  log_step "Dispatching request to provider"
+  echo "Command: $(command_string run --prompt "$OPENAI_PROMPT" --provider "$OPENAI_SPEC" --audit-target stdout)"
+  if response=$(run_cli run \
     --prompt "$OPENAI_PROMPT" \
     --provider "$OPENAI_SPEC" \
-    --audit-target stdout
+    --audit-target stdout 2>&1); then
+    print_response "$response"
+  else
+    echo "$response"
+  fi
 else
   echo "Skipping GPT-5 run: set OPENAI_API_KEY to hit the live provider."
 fi
 echo
 
 echo "== Preview Claude Sonnet thinking payload =="
-run_cli preview \
+log_step "Translating prompt to provider request"
+echo "Command: $(command_string preview --prompt "$ANTHROPIC_PROMPT" --provider "$ANTHROPIC_SPEC")"
+preview_output=$(run_cli preview \
   --prompt "$ANTHROPIC_PROMPT" \
-  --provider "$ANTHROPIC_SPEC"
+  --provider "$ANTHROPIC_SPEC" 2>&1) || true
+print_preview "$preview_output"
 echo
 
 if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
   echo "== Executing Claude Sonnet thinking request =="
-  run_cli run \
+  log_step "Dispatching request to provider"
+  echo "Command: $(command_string run --prompt "$ANTHROPIC_PROMPT" --provider "$ANTHROPIC_SPEC" --audit-target stdout)"
+  if response=$(run_cli run \
     --prompt "$ANTHROPIC_PROMPT" \
     --provider "$ANTHROPIC_SPEC" \
-    --audit-target stdout
+    --audit-target stdout 2>&1); then
+    print_response "$response"
+  else
+    echo "$response"
+  fi
 else
   echo "Skipping Claude Sonnet run: set ANTHROPIC_API_KEY to hit the live provider."
 fi

--- a/examples/node_basic.mjs
+++ b/examples/node_basic.mjs
@@ -2,6 +2,8 @@
 // Specado Node demo showcasing reasoning (OpenAI) and thinking (Anthropic).
 
 import { readFile } from 'node:fs/promises';
+import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 
@@ -111,7 +113,44 @@ function warnIfNoApiKey(varName) {
   }
 }
 
+function configEnvPath() {
+  if (process.platform === 'win32') {
+    const base = process.env.APPDATA ?? path.join(os.homedir(), 'AppData', 'Roaming');
+    return base ? path.join(base, 'specado', '.env') : null;
+  }
+  const base = process.env.XDG_CONFIG_HOME ?? path.join(os.homedir(), '.config');
+  return path.join(base, 'specado', '.env');
+}
+
+function loadEnvFile(filePath, { override }) {
+  if (!filePath) return;
+  try {
+    const data = fs.readFileSync(filePath, 'utf8');
+    for (const rawLine of data.split(/\r?\n/)) {
+      const line = rawLine.trim();
+      if (!line || line.startsWith('#') || !line.includes('=')) continue;
+      const idx = line.indexOf('=');
+      const key = line.slice(0, idx).trim();
+      const value = line.slice(idx + 1).trim();
+      if (!key) continue;
+      if (override || !(key in process.env)) {
+        process.env[key] = value;
+      }
+    }
+  } catch (error) {
+    if (error && error.code !== 'ENOENT') {
+      console.warn(`warning: failed to read ${filePath}: ${error.message ?? error}`);
+    }
+  }
+}
+
+function loadEnv() {
+  loadEnvFile(configEnvPath(), { override: false });
+  loadEnvFile(path.resolve('.env'), { override: true });
+}
+
 async function main() {
+  loadEnv();
   const args = parseArgs(process.argv.slice(2));
   const scenarioName = SCENARIOS[args.scenario] ? args.scenario : 'openai-reasoning';
   if (scenarioName !== args.scenario) {

--- a/examples/prompts/anthropic_thinking.json
+++ b/examples/prompts/anthropic_thinking.json
@@ -13,12 +13,12 @@
   "strict_mode": "Warn",
   "metadata": {
     "anthropic_model": "claude-sonnet-4-5-20250929",
-    "anthropic_max_tokens": 512,
+    "anthropic_max_tokens": 1024,
     "thinking": {
       "type": "enabled",
-      "budget_tokens": 640
+      "budget_tokens": 1024
     },
     "anthropic_thinking_type": "enabled",
-    "anthropic_thinking_budget": 640
+    "anthropic_thinking_budget": 1024
   }
 }

--- a/examples/prompts/openai_reasoning.json
+++ b/examples/prompts/openai_reasoning.json
@@ -12,18 +12,16 @@
   ],
   "sampling": {
     "temperature": 0.3,
-    "top_p": 0.85,
-    "seed": 1337
+    "top_p": 0.85
   },
   "strict_mode": "Warn",
   "metadata": {
     "openai_model": "gpt-5",
-    "openai_max_output_tokens": 512,
+    "openai_max_output_tokens": 1024,
     "reasoning": {
-      "effort": "medium",
-      "budget_tokens": 1200
+      "effort": "low"
     },
-    "openai_reasoning_effort": "medium",
+    "openai_reasoning_effort": "low",
     "openai_text_verbosity": "low"
   }
 }

--- a/examples/python_basic.py
+++ b/examples/python_basic.py
@@ -41,6 +41,49 @@ SCENARIOS = {
 }
 
 
+def config_env_path() -> pathlib.Path:
+    if sys.platform == "win32":
+        base = os.environ.get("APPDATA")
+        if base is None:
+            base = pathlib.Path.home() / "AppData" / "Roaming"
+        else:
+            base = pathlib.Path(base)
+        return base / "specado" / ".env"
+
+    if sys.platform == "darwin":
+        return pathlib.Path.home() / "Library" / "Application Support" / "specado" / ".env"
+
+    base = pathlib.Path(os.environ.get("XDG_CONFIG_HOME", pathlib.Path.home() / ".config"))
+    return base / "specado" / ".env"
+
+
+def load_env_file(path: pathlib.Path, override: bool) -> None:
+    try:
+        data = path.read_text().splitlines()
+    except FileNotFoundError:
+        return
+    except OSError as exc:  # pragma: no cover - best effort logging
+        print(f"warning: unable to read {path}: {exc}", file=sys.stderr)
+        return
+
+    for raw_line in data:
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            continue
+        if override or key not in os.environ:
+            os.environ[key] = value
+
+
+def load_env() -> None:
+    load_env_file(config_env_path(), override=False)
+    load_env_file(pathlib.Path(".env"), override=True)
+
+
 def load_prompt(path: pathlib.Path) -> Dict[str, Any]:
     data = path.read_text()
     suffix = path.suffix.lower()
@@ -101,6 +144,7 @@ def run_openai_compat(args: argparse.Namespace, prompt_payload: Dict[str, Any]) 
 
 
 def main() -> None:
+    load_env()
     parser = argparse.ArgumentParser(description="Run the Specado Python demo")
     parser.add_argument(
         "--scenario",


### PR DESCRIPTION
## Summary
- auto-load API credentials from the OS config directory (plus .env overrides) for CLI, Python, and Node workflows
- surface provider error bodies in audit events so failures are actionable, and fully parse OpenAI responses payloads
- refresh demo prompts and logging:  now prints commands, previews, and provider text so runs are human-readable

## Testing
- cargo test --workspace
- ./examples/cli_demo.sh