### PR TITLE
fix(py): restore bundled providers in build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ node_modules/
 
 # Generated provider bundles for packaging
 crates/specado-node/providers/
+python/specado/providers/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="docs/assets/specado-logo.svg" alt="Specado logo" width="260" />
 </p>
 
-<p align="center"><strong>From Fragile Scripts to Bulletproof Specs</strong></p>
+<h2 align="center">From Fragile Scripts to Bulletproof Specs</h2>
 
 <p align="center">
   <a href="https://github.com/specado/specado/actions/workflows/ci.yml">
@@ -107,13 +107,13 @@ See `specado --help` for the full matrix of flags (`--messages-file`, `--reason`
 
 | Field | Required | Purpose |
 | --- | --- | --- |
-| `version` | ✅ | Schema version (currently `"1"`). |
-| `messages[]` | ✅ | Ordered turns (`system` / `user` / `assistant`). |
-| `sampling` | ⏱️ | Deterministic knobs (`temperature`, `top_p`, `seed`, …). |
-| `response` | 🎯 | Output contract (`text`, `json`, or `json_schema`). |
-| `tools` / `tool_choice` | 🔧 | Provider-agnostic tool definitions and selection. |
-| `strict_mode` | 🛡️ | `Warn` (default), `Strict`, or `Coerce` mismatch behaviour. |
-| `metadata` | 🗂️ | Free-form hints for adapters (routing, tracing, etc.). |
+| `version` | Required | Schema version (currently `"1"`). |
+| `messages[]` | Required | Ordered turns (`system` / `user` / `assistant`). |
+| `sampling` | Optional | Deterministic knobs (`temperature`, `top_p`, `seed`, …). |
+| `response` | Optional | Output contract (`text`, `json`, or `json_schema`). |
+| `tools` / `tool_choice` | Optional | Provider-agnostic tool definitions and selection. |
+| `strict_mode` | Optional | `Warn` (default), `Strict`, or `Coerce` mismatch behaviour. |
+| `metadata` | Optional | Free-form hints for adapters (routing, tracing, etc.). |
 
 Authoritative references live in [`crates/specado-core/src/types/prompt.rs`](crates/specado-core/src/types/prompt.rs) and [`crates/specado-schemas/schemas/prompt-spec.v1.schema.json`](crates/specado-schemas/schemas/prompt-spec.v1.schema.json).
 

--- a/crates/specado-py/build.rs
+++ b/crates/specado-py/build.rs
@@ -1,0 +1,39 @@
+use std::env;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+fn copy_providers(from: &Path, to: &Path) -> io::Result<()> {
+    if to.exists() {
+        fs::remove_dir_all(to)?;
+    }
+    fs::create_dir_all(to)?;
+
+    fn copy_dir(src: &Path, dst: &Path) -> io::Result<()> {
+        for entry in fs::read_dir(src)? {
+            let entry = entry?;
+            let file_type = entry.file_type()?;
+            let src_path = entry.path();
+            let dst_path = dst.join(entry.file_name());
+            if file_type.is_dir() {
+                fs::create_dir_all(&dst_path)?;
+                copy_dir(&src_path, &dst_path)?;
+            } else if file_type.is_file() {
+                fs::copy(&src_path, &dst_path)?;
+            }
+        }
+        Ok(())
+    }
+
+    copy_dir(from, to)
+}
+
+fn main() -> io::Result<()> {
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("cargo manifest dir"));
+    let source = manifest_dir.join("../specado-providers/providers");
+    let destination = manifest_dir.join("../../python/specado/providers");
+
+    println!("cargo:rerun-if-changed={}", source.display());
+
+    copy_providers(&source, &destination)
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,4 +21,3 @@ python-source = "python"
 module-name = "specado._native"
 manifest-path = "crates/specado-py/Cargo.toml"
 features = ["pyo3/extension-module"]
-data = { "specado/providers" = "crates/specado-providers/providers" }


### PR DESCRIPTION
## Summary
- restore a `build.rs` step for the Python crate that stages `crates/specado-providers/providers` into `python/specado/providers`
- keep the generated directory out of git via .gitignore
- rely on the build script instead of the unsupported [tool.maturin] data mapping to fix CI packaging

## Testing
- source python/.venv/bin/activate && python -m pip install --upgrade pip && python -m pip install maturin pytest && python -m maturin develop -m crates/specado-py/Cargo.toml && python -m pytest python/tests
