### PR TITLE
release: 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2623,7 +2623,7 @@ dependencies = [
 
 [[package]]
 name = "specado-cli-temp"
-version = "0.2.0-alpha.27"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2644,7 +2644,7 @@ dependencies = [
 
 [[package]]
 name = "specado-core-temp"
-version = "0.2.0-alpha.27"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "criterion",
@@ -2667,7 +2667,7 @@ dependencies = [
 
 [[package]]
 name = "specado-node"
-version = "0.2.0-alpha.27"
+version = "0.2.0"
 dependencies = [
  "napi",
  "napi-build",
@@ -2680,11 +2680,11 @@ dependencies = [
 
 [[package]]
 name = "specado-providers"
-version = "0.2.0-alpha.27"
+version = "0.2.0"
 
 [[package]]
 name = "specado-py"
-version = "0.2.0-alpha.27"
+version = "0.2.0"
 dependencies = [
  "once_cell",
  "pyo3",
@@ -2696,7 +2696,7 @@ dependencies = [
 
 [[package]]
 name = "specado-schemas-temp"
-version = "0.2.0-alpha.27"
+version = "0.2.0"
 dependencies = [
  "jsonschema",
  "once_cell",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "specado-temp"
-version = "0.2.0-alpha.27"
+version = "0.2.0"
 dependencies = [
  "specado-core-temp",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0-alpha.27"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/specado/specado"
@@ -38,9 +38,9 @@ httpmock = "0.7"
 tempfile = "3.10"
 pythonize = "0.22.0"
 pyo3 = { version = "0.22.6", features = ["extension-module", "abi3-py39"] }
-specado-core = { path = "crates/specado-core", package = "specado-core-temp", default-features = false, version = "=0.2.0-alpha.27" }
-specado-schemas = { path = "crates/specado-schemas", package = "specado-schemas-temp", version = "=0.2.0-alpha.27" }
-specado = { path = "crates/specado", package = "specado-temp", version = "=0.2.0-alpha.27" }
+specado-core = { path = "crates/specado-core", package = "specado-core-temp", default-features = false, version = "=0.2.0" }
+specado-schemas = { path = "crates/specado-schemas", package = "specado-schemas-temp", version = "=0.2.0" }
+specado = { path = "crates/specado", package = "specado-temp", version = "=0.2.0" }
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="docs/assets/specado-logo.svg" alt="Specado logo" width="260" />
 </p>
 
-<h2 align="center">From Fragile Scripts to Bulletproof Specs</h2>
+<h1 align="center">From Fragile Scripts to Bulletproof Specs</h1>
 
 <p align="center">
   <a href="https://github.com/specado/specado/actions/workflows/ci.yml">
@@ -11,9 +11,9 @@
   <a href="https://github.com/specado/specado/blob/master/LICENSE">
     <img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-0A0A0A?label=license">
   </a>
-  <img alt="Crates.io" src="https://img.shields.io/badge/cargo-0.2.0--alpha.27-3B82F6?logo=rust">
-  <img alt="npm" src="https://img.shields.io/badge/npm-0.2.0--alpha.27-CB3837?logo=npm">
-  <img alt="PyPI" src="https://img.shields.io/badge/pypi-0.2.0--alpha.27-3776AB?logo=pypi">
+  <img alt="Crates.io" src="https://img.shields.io/badge/cargo-0.2.0-3B82F6?logo=rust">
+  <img alt="npm" src="https://img.shields.io/badge/npm-0.2.0-CB3837?logo=npm">
+  <img alt="PyPI" src="https://img.shields.io/badge/pypi-0.2.0-3776AB?logo=pypi">
 </p>
 
 ---
@@ -48,7 +48,7 @@ Specado replaces fragile prompt scripts with a spec-first workflow. Define your 
 - **Rust core**
   ```toml
   [dependencies]
-  specado = "0.2.0-alpha.27"
+  specado = "0.2.0"
   tokio = { version = "1", features = ["full"] }
   ```
 

--- a/crates/specado-node/package-lock.json
+++ b/crates/specado-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "specado",
-  "version": "0.2.0-alpha.25",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "specado",
-      "version": "0.2.0-alpha.25",
+      "version": "0.2.0",
       "dependencies": {
         "@napi-rs/cli": "^2.18.4"
       },
@@ -17,12 +17,12 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "specado-darwin-arm64": "0.2.0-alpha.25",
-        "specado-darwin-x64": "0.2.0-alpha.25",
-        "specado-linux-arm64-gnu": "0.2.0-alpha.25",
-        "specado-linux-x64-gnu": "0.2.0-alpha.25",
-        "specado-linux-x64-musl": "0.2.0-alpha.25",
-        "specado-win32-x64-msvc": "0.2.0-alpha.25"
+        "specado-darwin-arm64": "0.2.0",
+        "specado-darwin-x64": "0.2.0",
+        "specado-linux-arm64-gnu": "0.2.0",
+        "specado-linux-x64-gnu": "0.2.0",
+        "specado-linux-x64-musl": "0.2.0",
+        "specado-win32-x64-msvc": "0.2.0"
       }
     },
     "node_modules/@napi-rs/cli": {

--- a/crates/specado-node/package.json
+++ b/crates/specado-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "specado",
-  "version": "0.2.0-alpha.27",
+  "version": "0.2.0",
   "main": "index.js",
   "types": "index.d.ts",
   "files": [
@@ -39,11 +39,11 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "specado-win32-x64-msvc": "0.2.0-alpha.27",
-    "specado-darwin-x64": "0.2.0-alpha.27",
-    "specado-linux-x64-gnu": "0.2.0-alpha.27",
-    "specado-darwin-arm64": "0.2.0-alpha.27",
-    "specado-linux-arm64-gnu": "0.2.0-alpha.27",
-    "specado-linux-x64-musl": "0.2.0-alpha.27"
+    "specado-win32-x64-msvc": "0.2.0",
+    "specado-darwin-x64": "0.2.0",
+    "specado-linux-x64-gnu": "0.2.0",
+    "specado-darwin-arm64": "0.2.0",
+    "specado-linux-arm64-gnu": "0.2.0",
+    "specado-linux-x64-musl": "0.2.0"
   }
 }

--- a/docs/README.registry.md
+++ b/docs/README.registry.md
@@ -125,7 +125,7 @@ The constructor accepts either a friendly provider name or a spec path. Optional
 
 ```toml
 [dependencies]
-specado = "0.2.0-alpha.27"
+specado = "0.2.0"
 tokio = { version = "1", features = ["full"] }
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "specado"
-version = "0.2.0-alpha.27"
+version = "0.2.0"
 description = "Spec-driven LLM abstraction library"
 requires-python = ">=3.9"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## Summary
- bump all surfaces to 0.2.0 and refresh badges
- align README guidance with bundled providers and env overrides
- ensure Node lockfile and packaging metadata match final release